### PR TITLE
fix: 로그인/회원가입 레이아웃 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
         async
         src="https://www.googletagmanager.com/gtag/js?id=G-LE0LKNB3BT"
       />
-      <body>
+      <body className="select-none">
         <QueryProviders>{children}</QueryProviders>
       </body>
     </html>

--- a/src/app/signup/layout.tsx
+++ b/src/app/signup/layout.tsx
@@ -1,25 +1,43 @@
 "use client";
 
+/* eslint-disable no-nested-ternary */
 import Image from "next/image";
 import { usePathname } from "next/navigation";
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useState } from "react";
 
 export default function SignupLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname();
+  const [isSmallHeight, setIsSmallHeight] = useState(false);
+
+  useEffect(() => {
+    const checkHeight = () => {
+      setIsSmallHeight(window.innerHeight < 800);
+    };
+
+    checkHeight();
+    window.addEventListener("resize", checkHeight);
+    return () => window.removeEventListener("resize", checkHeight);
+  }, []);
 
   return (
-    <div className="relative flex h-screen w-screen flex-row items-center justify-center">
+    <div className="relative flex min-h-screen w-screen flex-row items-center justify-center">
       <div className="relative flex h-full justify-between md:w-[936px] lg:w-[1860px]">
         <div
-          className={`flex flex-col items-center ${pathname === "/login" ? "justify-center" : "justify-center md:justify-start"} justify-self-start md:w-[416px] md:px-[62px] md:py-8 lg:w-[660px] lg:px-[114px] lg:py-16`}
+          className={`flex flex-col items-center ${
+            pathname === "/login"
+              ? "justify-center"
+              : isSmallHeight
+                ? "justify-start py-[40px]"
+                : "justify-center md:justify-center"
+          } scroll- justify-self-start md:w-[416px] md:px-[62px] md:py-8 lg:w-[660px] lg:px-[114px] lg:py-16`}
         >
           {children}
         </div>
-        <div className="hidden items-center justify-center md:fixed md:right-4 md:flex md:h-[600px] md:w-[520px] lg:relative lg:h-[1080px] lg:w-[1200px]">
+        <div className="relative hidden h-screen w-full items-center justify-center md:flex">
           <Image
             src="/images/login-cover.svg"
             alt="onboarding"
-            className="rounded-[24px] object-cover md:h-[568px] md:w-[488px] lg:h-[1032px] lg:w-[1152px]"
+            className="d:h-[568px] rounded-[24px] object-cover md:w-[488px] lg:h-[1032px] lg:w-[1152px]"
             width={488}
             height={568}
           />


### PR DESCRIPTION
## 🚀연관된 이슈

## 📝작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요

- 레이아웃 수정했습니다.
- 이전에는 피그마에 나와있는 사이즈만 작업했었는데, 여러 디바이스에 잘 적용될 수 있도록 수정했습니다.
- 모바일에서 800 height보다 작은 디바이스
  - 원래는 중앙 고정으로 스크롤 안됨 & 브라우저 밖에 컴포넌트가 나가버리는 상황
  - 위, 아래에 패딩 추가 + min-height 추가로 스크롤 생성
- 이미지 드래그 방지 걸어뒀습니다.

## 📷스크린샷 (선택)


## 💬리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요