### PR TITLE
feat: 웨이팅 관리 API 연결

### DIFF
--- a/src/app/device/layout.tsx
+++ b/src/app/device/layout.tsx
@@ -1,12 +1,27 @@
+import Image from "next/image";
 import { PropsWithChildren } from "react";
 
 export default function Layout({ children }: PropsWithChildren) {
   return (
-    <div>
-      <div className="flex h-full w-full items-center justify-center pt-4 md:hidden">
-        {children}
+    <div className="h-screen w-screen bg-gray-700">
+      <div className="hidden h-full w-full flex-col md:flex">
+        <header className="flex flex-col gap-6 px-[60px] pt-[40px]">
+          <div className="flex w-full items-center gap-5">
+            <Image
+              src="/logo/logo-medium.svg"
+              alt="모두의 웨이터 로고"
+              width={60}
+              height={60}
+            />
+            <h1 className="font-hakgyo text-primary text-2xl">모두의 웨이터</h1>
+          </div>
+          <div className="h-[1px] w-full bg-gray-500" />
+        </header>
+        <div className="flex flex-1 items-center justify-center pb-[112px]">
+          {children}
+        </div>
       </div>
-      <div className="hidden md:block">{children}</div>
+      <div className="flex md:hidden">{children}</div>
     </div>
   );
 }

--- a/src/app/device/page.tsx
+++ b/src/app/device/page.tsx
@@ -10,10 +10,6 @@ export default function Device() {
   const { step, setStep, storeId, setStoreId, phoneNumber, setPhoneNumber } =
     useDeviceUI();
 
-  // const { mutate: submitDevice } = useMutation({
-  //   mutationFn: addDevice,
-  // });
-
   return (
     <div
       className={cn(

--- a/src/app/hall/_components/CallingCard.tsx
+++ b/src/app/hall/_components/CallingCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/components/common/Button/Button";
+import Button from "@/components/common/Button/Button";
 import useOverlay from "@/hooks/use-overlay";
 import CompleteAllModal from "./CompleteAllModal";
 

--- a/src/app/hall/_components/CompleteAllModal.tsx
+++ b/src/app/hall/_components/CompleteAllModal.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/common/Button/Button";
+import Button from "@/components/common/Button/Button";
 import ModalWithTitle from "@/components/modal/largeModalLayout";
 
 interface IProps {

--- a/src/app/hall/_components/Header.tsx
+++ b/src/app/hall/_components/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/components/common/Button/Button";
+import Button from "@/components/common/Button/Button";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 

--- a/src/app/hall/_components/OrderCard.tsx
+++ b/src/app/hall/_components/OrderCard.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/common/Button/Button";
+import Button from "@/components/common/Button/Button";
 import cn from "@/lib/utils";
 import { PlusIcon } from "lucide-react";
 

--- a/src/app/hall/_components/OrderRow.tsx
+++ b/src/app/hall/_components/OrderRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/components/common/Button/Button";
+import Button from "@/components/common/Button/Button";
 import { ScrollArea, ScrollBar } from "@/components/common/ScrollArea";
 import cn from "@/lib/utils";
 import useOverlay from "@/hooks/use-overlay";

--- a/src/app/hall/page.tsx
+++ b/src/app/hall/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/components/common/Button/Button";
+import Button from "@/components/common/Button/Button";
 import { ScrollArea, ScrollBar } from "@/components/common/ScrollArea";
 import { useState } from "react";
 import cn from "@/lib/utils";

--- a/src/app/menu/preview/page.tsx
+++ b/src/app/menu/preview/page.tsx
@@ -1,0 +1,3 @@
+export default function MenuPreview() {
+  return <div>preview</div>;
+}

--- a/src/app/waiting/_components/WaitingModal.tsx
+++ b/src/app/waiting/_components/WaitingModal.tsx
@@ -2,30 +2,40 @@ import Icon from "@/components/common/Icon";
 import ResponsiveButton from "@/components/common/Button/ResponsiveButton";
 import ModalWithTitle from "@/components/modal/largeModalLayout";
 import transformPhoneNumber from "@/lib/formatting/transformPhoneNumber";
+import getQueryClient from "@/app/get-query-client";
+import useWaiting from "../_hooks/useWaiting";
+import useElapsedMinutes from "../_hooks/useElapsedMinutes";
 
-interface IProps {
+interface IProps extends Waiting {
   close: () => void;
-  type: "call" | "enter" | "cancel";
-  // waitingId: bigint;
+  type: "call" | "complete" | "cancel";
 }
 
-export default function WaitingModal({ close, type }: IProps) {
-  const [adult, infant] = [2, 1];
+const queryClient = getQueryClient();
+
+export default function WaitingModal({ close, type, ...waiting }: IProps) {
+  const { mutateAction } = useWaiting();
+  const elapsedCreatedAt = useElapsedMinutes(waiting.createdAt);
+  const elapsedLastCall = useElapsedMinutes(waiting.lastCallTime);
 
   const handleTitle = () => {
-    if (type === "call") {
-      return "호출";
-    }
-    if (type === "enter") {
-      return "입장";
-    }
-    if (type === "cancel") {
-      return "취소";
-    }
+    if (type === "call") return "호출";
+    if (type === "complete") return "입장";
+    if (type === "cancel") return "취소";
     return "";
   };
 
-  const handleCall = () => {};
+  const handleCall = () => {
+    mutateAction(
+      { waitingId: String(waiting.waitingId), type },
+      {
+        onSuccess: () => {
+          close();
+          queryClient.invalidateQueries({ queryKey: ["waiting-list"] });
+        },
+      }
+    );
+  };
 
   return (
     <ModalWithTitle
@@ -37,37 +47,39 @@ export default function WaitingModal({ close, type }: IProps) {
         <div className="flex h-[275px] flex-row items-center gap-4 rounded-[24px] bg-gray-700 p-5">
           <div className="flex flex-1 flex-col items-center gap-4">
             <span className="text-lg font-medium">대기 번호</span>
-            <strong className="text-4xl font-bold">001</strong>
+            <strong className="text-4xl font-bold">
+              {String(waiting.number).padStart(3, "0")}
+            </strong>
           </div>
           <div className="flex h-full w-[308px] flex-col rounded-[24px] bg-white p-5">
             <div className="flex h-10 w-fit flex-row items-center justify-center rounded-[24px] bg-gray-700 px-3 py-2">
               <div className="flex flex-row items-center">
-                <Icon iconKey="smile" className="mt-[7px]" />
-                <span>성인 {adult}</span>
+                <Icon iconKey="smile" />
+                <span>성인 {waiting.adult}</span>
               </div>
-              {infant > 0 && (
+              {waiting.infant > 0 && (
                 <>
                   <div className="mx-3 h-[16px] w-[1px] bg-gray-100" />
                   <div className="flex flex-row items-center">
-                    <Icon iconKey="baby" className="mt-2" />
-                    <span className="mt-[1px]">아동 {infant}</span>
+                    <Icon iconKey="baby" />
+                    <span className="mt-[1px]">아동 {waiting.infant}</span>
                   </div>
                 </>
               )}
             </div>
             <strong className="mt-3 text-[28px] font-bold">
-              총 {adult + infant}명
+              총 {waiting.adult + waiting.infant}명
             </strong>
             <div className="mt-6 flex flex-col gap-3">
               <strong className="text-gray-0 decoration-gray-0 text-xl font-semibold underline decoration-1 underline-offset-[8px]">
-                {transformPhoneNumber("01012345678")}
+                {transformPhoneNumber(waiting.phoneNumber)}
               </strong>
               <div className="flex w-fit flex-row gap-3 rounded-[8px] bg-gray-700 px-4 py-[6px]">
                 <span className="text-gray-0 text-lg font-semibold">
-                  24분 경과
+                  {elapsedCreatedAt}분 경과
                 </span>
                 <span className="text-status-error text-lg font-semibold">
-                  15:14:24
+                  {waiting.createdAt.split(" ")[1]}
                 </span>
               </div>
             </div>
@@ -80,31 +92,33 @@ export default function WaitingModal({ close, type }: IProps) {
                 lg: {
                   buttonSize: "xl",
                   className:
-                    "bg-gray-700 rounded-[12px] px-5 py-3 flex items-center justify-between !text-gray-0 w-full",
+                    "!border-gray-700 bg-gray-700 rounded-[12px] px-5 py-3 flex items-center justify-between !text-gray-0 w-full",
                 },
               }}
             >
               <span className="text-base">총 호출한 횟수</span>
-              <span className="text-lg">6회</span>
+              <span className="text-lg">{waiting.callCount}회</span>
             </ResponsiveButton>
-            <ResponsiveButton
-              variant="outline"
-              color="primary"
-              responsiveButtons={{
-                lg: {
-                  buttonSize: "xl",
-                  className:
-                    "rounded-[12px] px-[20px] py-[12px] flex items-center justify-between !text-status-error w-full !border-status-error",
-                },
-              }}
-            >
-              <span className="text-base">마지막 호출 시간</span>
-              <span className="text-lg">15분 전</span>
-            </ResponsiveButton>
+            {elapsedLastCall <= 100 && (
+              <ResponsiveButton
+                variant="outline"
+                color="primary"
+                responsiveButtons={{
+                  lg: {
+                    buttonSize: "xl",
+                    className:
+                      "rounded-[12px] px-[20px] py-[12px] flex items-center justify-between !text-status-error w-full !border-status-error",
+                  },
+                }}
+              >
+                <span className="text-base">마지막 호출 시간</span>
+                <span className="text-lg">{elapsedLastCall}분 전</span>
+              </ResponsiveButton>
+            )}
           </div>
         )}
         <div className="font-regular text-gray-0 my-10 text-center text-lg">
-          {type === "enter" ? (
+          {type === "complete" ? (
             <div className="flex flex-col gap-[1px]">
               <span>위 손님이 입장하셨나요?</span>
               <span>입장하셨다면 입장 버튼을 눌러 상태를 바꿔주세요.</span>
@@ -117,7 +131,7 @@ export default function WaitingModal({ close, type }: IProps) {
       <ModalWithTitle.ButtonGroup
         saveBtn={{
           text: handleTitle(),
-          onClick: handleCall,
+          onClick: () => handleCall(),
           disabled: false,
         }}
         cancelBtn={{ text: "닫기", onClick: close, disabled: false }}

--- a/src/app/waiting/_components/WaitingSection.tsx
+++ b/src/app/waiting/_components/WaitingSection.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import Icon from "@/components/common/Icon";
 import transformPhoneNumber from "@/lib/formatting/transformPhoneNumber";
 import ActionButton from "./ActionButton";
+import useElapsedMinutes from "../_hooks/useElapsedMinutes";
 
 interface IProps extends Waiting {
   onCall: () => void;
@@ -14,19 +17,21 @@ export default function WaitingSection({
   onCancel,
   ...waiting
 }: IProps) {
+  const elapsedMinutes = useElapsedMinutes(waiting.createdAt);
+
   return (
     <div className="flex flex-1 flex-row items-center justify-between rounded-[16px] bg-white px-10 py-8">
       <div>
         <div className="mb-4 flex h-10 w-fit flex-row items-center justify-center rounded-[24px] bg-gray-700 px-3 py-2">
           <div className="flex flex-row items-center">
-            <Icon iconKey="smile" className="mt-[7px]" />
+            <Icon iconKey="smile" />
             <span>성인 {waiting.adult}</span>
           </div>
           {waiting.infant > 0 && (
             <>
               <div className="mx-3 h-[16px] w-[1px] bg-gray-100" />
               <div className="flex flex-row items-center">
-                <Icon iconKey="baby" className="mt-2" />
+                <Icon iconKey="baby" />
                 <span className="mt-[1px]">아동 {waiting.infant}</span>
               </div>
             </>
@@ -40,9 +45,11 @@ export default function WaitingSection({
             {transformPhoneNumber(waiting.phoneNumber)}
           </strong>
           <div className="flex flex-row gap-2 rounded-[8px] bg-gray-700 px-4 py-[6px]">
-            <span className="text-gray-0 text-lg font-semibold">24분 경과</span>
+            <span className="text-gray-0 text-lg font-semibold">
+              {elapsedMinutes}분 경과
+            </span>
             <span className="text-status-error text-lg font-semibold">
-              15:14:24
+              {waiting.createdAt.split(" ")[1]}
             </span>
           </div>
         </div>
@@ -50,7 +57,7 @@ export default function WaitingSection({
       <div className="flex flex-row gap-5">
         <ActionButton
           type="button"
-          iconKey="bell-ringing-02"
+          iconKey="bell"
           className="text-white"
           text="호출"
           onClick={onCall}
@@ -66,7 +73,7 @@ export default function WaitingSection({
         />
         <ActionButton
           type="button"
-          iconKey="x-circle-contained"
+          iconKey="xcircle"
           color="grey"
           text="취소"
           onClick={onCancel}

--- a/src/app/waiting/_hooks/useDeviceInfo.tsx
+++ b/src/app/waiting/_hooks/useDeviceInfo.tsx
@@ -1,0 +1,31 @@
+import { useState, useEffect } from "react";
+import { getSecureItem } from "@/lib/auth/localStorage";
+
+export default function useDeviceInfo() {
+  const [deviceInfo, setDeviceInfo] = useState<Pick<
+    Device,
+    "deviceId" | "name" | "purpose"
+  > | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchDeviceInfo = async () => {
+      try {
+        setIsLoading(true);
+        const value = await getSecureItem("deviceInfo");
+        setDeviceInfo(value);
+        setError(null);
+      } catch (err: any) {
+        setError(err);
+        setDeviceInfo(null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchDeviceInfo();
+  }, []);
+
+  return { deviceInfo, isLoading, error };
+}

--- a/src/app/waiting/_hooks/useElapsedMinutes.tsx
+++ b/src/app/waiting/_hooks/useElapsedMinutes.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+
+export default function useElapsedMinutes(dateString: string | Date | null) {
+  const [elapsedMinutes, setElapsedMinutes] = useState(0);
+
+  useEffect(() => {
+    if (!dateString) return undefined;
+
+    const calculateElapsedTime = () => {
+      try {
+        const createdDate =
+          typeof dateString === "string" ? new Date(dateString) : dateString;
+        const now = new Date();
+
+        if (Number.isNaN(createdDate.getTime())) {
+          setElapsedMinutes(0);
+          return;
+        }
+
+        const diffInMilliseconds = now.getTime() - createdDate.getTime();
+        const minutes = Math.floor(diffInMilliseconds / (1000 * 60));
+        setElapsedMinutes(minutes);
+      } catch (error) {
+        setElapsedMinutes(0);
+      }
+    };
+
+    calculateElapsedTime();
+    const intervalId = setInterval(calculateElapsedTime, 60000);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [dateString]);
+
+  return elapsedMinutes;
+}

--- a/src/app/waiting/_hooks/useWaiting.tsx
+++ b/src/app/waiting/_hooks/useWaiting.tsx
@@ -1,0 +1,30 @@
+import getQueryClient from "@/app/get-query-client";
+import { addWaiting, waitingAction, waitingList } from "@/lib/api/waiting.api";
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+const queryClient = getQueryClient();
+
+export default function useWaiting(enabled = true) {
+  const { data: list } = useQuery({
+    queryKey: ["waiting-list"],
+    queryFn: waitingList,
+    enabled,
+  });
+
+  const { mutate: mutateWaiting } = useMutation({
+    mutationFn: addWaiting,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["waiting-list"] });
+    },
+  });
+
+  const { mutate: mutateAction } = useMutation({
+    mutationFn: waitingAction,
+  });
+
+  return {
+    list,
+    mutateWaiting,
+    mutateAction,
+  };
+}

--- a/src/app/waiting/_hooks/useWaitingModal.tsx
+++ b/src/app/waiting/_hooks/useWaitingModal.tsx
@@ -1,0 +1,20 @@
+import useOverlay from "@/hooks/use-overlay";
+import QueryProviders from "@/app/query-providers";
+import WaitingModal from "../_components/WaitingModal";
+
+export default function useWaitingModal() {
+  const { open, close } = useOverlay();
+
+  const handleOpenModal = (
+    type: "call" | "complete" | "cancel",
+    waiting: Waiting
+  ) => {
+    open(() => (
+      <QueryProviders>
+        <WaitingModal close={close} type={type} {...waiting} />
+      </QueryProviders>
+    ));
+  };
+
+  return { handleOpenModal };
+}

--- a/src/app/waiting/cancel/page.tsx
+++ b/src/app/waiting/cancel/page.tsx
@@ -1,0 +1,3 @@
+export default function CancelWaiting() {
+  return <div>cancel</div>;
+}

--- a/src/app/waiting/my-turn/page.tsx
+++ b/src/app/waiting/my-turn/page.tsx
@@ -1,0 +1,3 @@
+export default function CheckMyTurn() {
+  return <div>waiting my turn</div>;
+}

--- a/src/app/waiting/page.tsx
+++ b/src/app/waiting/page.tsx
@@ -1,55 +1,47 @@
 "use client";
 
 import ResponsiveButton from "@/components/common/Button/ResponsiveButton";
-import useOverlay from "@/hooks/use-overlay";
-import QueryProviders from "@/app/query-providers";
 import { useRouter } from "next/navigation";
-import WaitingModal from "./_components/WaitingModal";
 import WaitingSection from "./_components/WaitingSection";
-
-const dummy: Waiting[] = [
-  {
-    waitingId: BigInt("694865267482835533"),
-    phoneNumber: "01044591812",
-    adult: 2,
-    infant: 0,
-    number: 1,
-    callCount: 0,
-    lastCallTime: "1970-01-01 00:00:00",
-    state: "REGISTRATION",
-    createdAt: "2025-01-01 12:00:00",
-  },
-  {
-    waitingId: BigInt("694865267482835536"),
-    phoneNumber: "01044591813",
-    adult: 2,
-    infant: 1,
-    number: 1,
-    callCount: 0,
-    lastCallTime: "1970-01-01 00:00:00",
-    state: "REGISTRATION",
-    createdAt: "2025-01-01 12:00:00",
-  },
-];
+import useWaiting from "./_hooks/useWaiting";
+import useDeviceInfo from "./_hooks/useDeviceInfo";
+import useWaitingModal from "./_hooks/useWaitingModal";
 
 export default function Waiting() {
   const navigate = useRouter();
-  const { open, close } = useOverlay();
+  const { deviceInfo, isLoading } = useDeviceInfo();
+  const { handleOpenModal } = useWaitingModal();
 
-  const handleOpenModal = (type: "call" | "enter" | "cancel") => {
-    open(() => (
-      <QueryProviders>
-        <WaitingModal close={close} type={type} />
-      </QueryProviders>
-    ));
-  };
+  const waitingEnabled = !!deviceInfo?.deviceId && !isLoading;
+  const { list } = useWaiting(waitingEnabled);
+
+  // const handleAddWaiting = () => {
+  //   mutateWaiting({
+  //     phoneNumber: '01036833426',
+  //     adult: 1,
+  //     infant: 3
+  //   })
+  // }
 
   return (
     <div className="min-h-screen w-screen bg-gray-700">
       <header className="fixed flex w-full flex-col gap-6 bg-gray-700 px-15 pt-10">
         <div className="flex w-full flex-row items-center justify-between">
           <strong className="text-3xl font-bold">웨이팅 관리</strong>
-          <div className="relative">
+          <div className="relative flex">
+            {/* Test */}
+            {/* <ResponsiveButton
+              color="grey"
+              responsiveButtons={{
+                lg: {
+                  buttonSize: "xl",
+                  className: "bg-gray-300 text-white text-lg font-semibold",
+                },
+              }}
+              onClick={handleAddWaiting}
+            >
+              웨이팅 추가
+            </ResponsiveButton> */}
             <ResponsiveButton
               color="grey"
               responsiveButtons={{
@@ -72,22 +64,22 @@ export default function Waiting() {
       <div className="flex w-full flex-row gap-4 px-15 pt-38 pb-8">
         <section className="flex w-full flex-row gap-[25px]">
           <div className="flex w-12 flex-col gap-4">
-            {dummy.map((item, index) => (
+            {list?.waitings?.map((item, index) => (
               <div
                 className="center relative h-[225px] w-12"
                 key={item.waitingId}
               >
-                {index !== dummy.length - 1 && (
+                {index !== (list?.waitings?.length ?? 0) - 1 && (
                   <div className="absolute top-36 bottom-0 left-1/2 z-0 h-45 w-[2px] -translate-x-1/2 bg-gray-100" />
                 )}
                 <div className="center text- h-12 w-12 rounded-full bg-gray-100 text-xl font-semibold text-white">
-                  {String(index + 1).padStart(2, "0")}
+                  {String(index + 1).padStart(3, "0")}
                 </div>
               </div>
             ))}
           </div>
           <div className="flex w-full flex-col gap-4">
-            {dummy.map((item, index) => (
+            {list?.waitings?.map((item) => (
               <div
                 className="flex h-[225px] w-full flex-row gap-2"
                 key={item.waitingId}
@@ -95,14 +87,14 @@ export default function Waiting() {
                 <div className="flex w-[160px] flex-col items-center justify-center gap-2 rounded-[16px] bg-white">
                   <span className="text-lg font-medium">대기 번호</span>
                   <strong className="text-4xl font-bold">
-                    {String(index + 1).padStart(3, "0")}
+                    {String(item.number).padStart(3, "0")}
                   </strong>
                 </div>
                 <WaitingSection
                   {...item}
-                  onCall={() => handleOpenModal("call")}
-                  onCancel={() => handleOpenModal("cancel")}
-                  onEnterance={() => handleOpenModal("enter")}
+                  onCall={() => handleOpenModal("call", item)}
+                  onCancel={() => handleOpenModal("cancel", item)}
+                  onEnterance={() => handleOpenModal("complete", item)}
                 />
               </div>
             ))}

--- a/src/constants/translates.ts
+++ b/src/constants/translates.ts
@@ -23,6 +23,7 @@ export const paymentTimeTranslate = {
 } as const;
 
 export const deviceTranslate = {
+  POS: "POS",
   TABLE: "테이블",
   HALL: "홀",
   WAITING: "웨이팅",

--- a/src/lib/api/paths.ts
+++ b/src/lib/api/paths.ts
@@ -3,6 +3,7 @@ const API_PATH = {
   account: "/accounts",
   stores: "/stores",
   devices: "/devices",
+  waitings: "/waitings",
 };
 
 export default API_PATH;

--- a/src/lib/api/stores.api.ts
+++ b/src/lib/api/stores.api.ts
@@ -1,5 +1,5 @@
 import { TypeCategory } from "@/schema/store.schema";
-import { formInstance, instance } from "../axios/instance";
+import { formInstance, instance, signatureInstance } from "../axios/instance";
 import API_PATH from "./paths";
 
 export const registerStore = async (body: FormData) => {
@@ -114,5 +114,11 @@ export const getMenusWithCategory = async (
   storeId: string
 ): Promise<MenuListWithCategory> => {
   const response = await instance.get(`${API_PATH.stores}/${storeId}/menus`);
+  return response.data;
+};
+
+// 스토어 오픈/클로즈
+export const postStoreAction = async (type: "open" | "close") => {
+  const response = await signatureInstance.post(`${API_PATH.stores}/${type}`);
   return response.data;
 };

--- a/src/lib/api/waiting.api.ts
+++ b/src/lib/api/waiting.api.ts
@@ -2,7 +2,7 @@ import { signatureInstance } from "../axios/instance";
 import API_PATH from "./paths";
 
 export const waitingList = async (): Promise<{ waitings: Waiting[] }> => {
-  const response = await signatureInstance.get(`${API_PATH}/waitings`);
+  const response = await signatureInstance.get(`${API_PATH.waitings}`);
   return response.data;
 };
 

--- a/src/lib/api/waiting.api.ts
+++ b/src/lib/api/waiting.api.ts
@@ -1,0 +1,32 @@
+import { signatureInstance } from "../axios/instance";
+import API_PATH from "./paths";
+
+export const waitingList = async (): Promise<{ waitings: Waiting[] }> => {
+  const response = await signatureInstance.get(`${API_PATH}/waitings`);
+  return response.data;
+};
+
+export const waitingCount = async (): Promise<{ count: number }> => {
+  const response = await signatureInstance.get(`${API_PATH.waitings}/count`);
+  return response.data;
+};
+
+export const addWaiting = async (
+  body: Pick<Waiting, "phoneNumber" | "adult" | "infant">
+) => {
+  const response = await signatureInstance.post(`${API_PATH.waitings}`, body);
+  return response.data;
+};
+
+export const waitingAction = async ({
+  waitingId,
+  type,
+}: {
+  waitingId: string;
+  type: "complete" | "cancel" | "call";
+}) => {
+  const response = await signatureInstance.post(
+    `${API_PATH.waitings}/${waitingId}/${type}`
+  );
+  return response.data;
+};

--- a/src/lib/axios/instance.ts
+++ b/src/lib/axios/instance.ts
@@ -41,4 +41,4 @@ setupInterceptors(instance);
 setupInterceptors(formInstance);
 setupDeviceInterceptors(signatureInstance);
 
-export { instance, formInstance, authInstance };
+export { instance, formInstance, authInstance, signatureInstance };

--- a/src/lib/axios/interceptors.ts
+++ b/src/lib/axios/interceptors.ts
@@ -105,23 +105,105 @@ export const setupInterceptors = (axiosInstance: AxiosInstance) => {
   );
 };
 
+type CacheKey = `${string}:${string}:${string}`; 
+
+const signatureMutex = new Mutex();
+
+const signatureCache: Record<
+  CacheKey,
+  { timestamp: string; signature: string; createdAt: number }
+> = {};
+
+const getCacheKey = (method: string, uri: string, purpose: string) =>
+  `${method}:${uri}:${purpose}` as const;
+
 export const setupDeviceInterceptors = (axiosInstance: AxiosInstance) => {
   axiosInstance.interceptors.request.use(
     async (config) => {
-      const deviceInfo = await getSecureItem("deviceInfo");
-      const secretKey = await getSecureItem("secretKey");
+      const method = config.method?.toUpperCase() || "GET";
+      const uri = config.url || "/";
 
-      if (!deviceInfo || !secretKey) return config;
+      await signatureMutex.runExclusive(async () => {
+        const purpose = "HALL";
+        const key = getCacheKey(method, `/v1${uri}`, purpose);
+        const cached = signatureCache[key];
 
-      const timestamp = Date.now().toString();
-      const signature = makeSignature({ secretKey, timestamp, ...deviceInfo });
+        if (!cached || Date.now() - cached.createdAt > 1000) {
+          const deviceInfo = await getSecureItem("deviceInfo");
+          const secretKey = await getSecureItem("secretKey");
 
-      config.headers["x-ew-access-key"] = secretKey;
-      config.headers["x-ew-signature"] = signature;
-      config.headers["x-ew-timestamp"] = timestamp;
+          if (!deviceInfo || !secretKey) {
+            console.warn("❌ deviceInfo 또는 secretKey가 없습니다.");
+            return;
+          }
+
+          const timestamp = Date.now().toString();
+          const signature = makeSignature({
+            uri: `/v1${uri}`,
+            method,
+            secretKey,
+            timestamp,
+            purpose,
+            name: deviceInfo.name,
+            deviceId: deviceInfo.deviceId,
+          });
+
+          console.log("🧾 Signing Payload", {
+            method,
+            uri: `/v1${uri}`,
+            secretKey,
+            timestamp,
+            purpose,
+            name: deviceInfo.name,
+            deviceId: deviceInfo.deviceId,
+          });
+
+          console.log("🧾 Headers", {
+            "x-ew-access-key": deviceInfo.deviceId,
+            "x-ew-signature": signature,
+            "x-ew-timestamp": timestamp,
+          });
+
+          config.headers["x-ew-access-key"] = deviceInfo.deviceId;
+          config.headers["x-ew-signature"] = signature;
+          config.headers["x-ew-timestamp"] = timestamp;
+        }
+      });
 
       return config;
     },
     (error) => Promise.reject(error)
+  );
+
+  axiosInstance.interceptors.response.use(
+    (response) => {
+      // 응답 성공 시 처리
+      console.log("✅ Axios Response Success:", response);
+      return response;
+    },
+    (error) => {
+      // 응답 에러 발생 시 처리
+      console.error(
+        "❌ Axios Response Error:",
+        error.response || error.message || error
+      );
+
+      // 에러 응답 데이터 확인
+      if (error.response) {
+        // 서버가 응답했지만 상태 코드가 2xx 범위가 아닌 경우
+        console.error("   Status:", error.response.status);
+        console.error("   Data:", error.response.data); // <-- 여기가 에러 응답 데이터
+        console.error("   Headers:", error.response.headers);
+      } else if (error.request) {
+        // 요청이 만들어졌지만 응답을 받지 못한 경우 (예: 네트워크 문제)
+        console.error("   No response received for the request.");
+        console.error("   Request:", error.request);
+      } else {
+        // 오류를 발생시킨 요청을 설정하는 중에 문제가 발생한 경우
+        console.error("   Error setting up the request:", error.message);
+      }
+
+      return Promise.reject(error); // 에러를 다시 throw하여 호출자에게 전달
+    }
   );
 };

--- a/src/utils/make-signature.ts
+++ b/src/utils/make-signature.ts
@@ -4,15 +4,19 @@ import CryptoJS from "crypto-js";
 // 요청 헤더와 시그니처 생성 시 동일한 timestamp 사용
 // 5분 경과 시 사용 불가 (요청할 때마다 생성 권장)
 const makeSignature = ({
+  method,
+  uri,
   deviceId,
   purpose,
   name,
   secretKey,
   timestamp,
-}: Device & { secretKey: string; timestamp: string }) => {
-  const method = "GET";
-  const uri = "/v1/devices";
-
+}: Pick<Device, "deviceId" | "purpose" | "name"> & {
+  secretKey: string;
+  timestamp: string;
+  method: string;
+  uri: string;
+}) => {
   const hmac = CryptoJS.algo.HMAC.create(CryptoJS.algo.SHA256, secretKey);
   hmac.update(`${method} ${uri}`);
   hmac.update("\n");


### PR DESCRIPTION
## 📝작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요

- waiting API 연결 테스트 완료했습니다.
```
1. [WAITING] 웨이팅 생성 ✅
2. [HALL] 웨이팅 목록 조회 ✅
3. [HALL] 웨이팅 호출 ✅
4. [HALL] 웨이팅 완료 ✅
5. [HALL] 웨이팅 취소 ✅
```
- 아직 디바이스 테스트가 남았기 때문에 interceptor의 console.log는 추후 삭제하겠습니다.
- device interceptor에 mutex 추가
  - 같은 API가 여러번 호출되는거 보아하니 react-query enabled 문제인거 같았는데, 결과적으로 mutex까지 적용하고 나니 재렌더링 문제가 사라졌습니다.

## 🔍 이후 작업 순서
- API 나오는거 보고 순서대로 할 예정입니다.
- POS API 연결 -> 세팅 API 연결 -> 홀 API 연결 -> 전체 테스트