### PR TITLE
fix: QA 메뉴 모달 폼 관련 에러 수정

### DIFF
--- a/src/app/(device-required)/pos/_components/POSMenuCard.tsx
+++ b/src/app/(device-required)/pos/_components/POSMenuCard.tsx
@@ -18,6 +18,7 @@ const POSMenuCard = memo(({ onClick, ...props }: IProps) => (
         alt={`${props.name} 메뉴 이미지`}
         fill
         className="object-cover"
+        unoptimized
         priority
       />
     ) : (

--- a/src/app/(device-required)/pos/_components/modals/MenuModal.tsx
+++ b/src/app/(device-required)/pos/_components/modals/MenuModal.tsx
@@ -133,6 +133,7 @@ function MenuModal({
               className="object-cover"
               width={500}
               height={160}
+              unoptimized
             />
           )}
         </div>

--- a/src/app/(main)/(owner)/[id]/@modal/menu/[menuId]/category/[categoryId]/layout.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/menu/[menuId]/category/[categoryId]/layout.tsx
@@ -48,7 +48,7 @@ export default async function Layout({
   });
 
   return (
-    <ClientRefWrapper className="md:h-[621px] md:w-[912px] lg:h-[832px] lg:w-[1344px]">
+    <ClientRefWrapper className="aspect-[1344/832] md:h-auto md:w-[1000px] lg:h-[832px] lg:w-[1344px]">
       {children}
     </ClientRefWrapper>
   );

--- a/src/app/(main)/(owner)/[id]/@modal/menu/_components/DetailMenuModal/ImageSection.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/menu/_components/DetailMenuModal/ImageSection.tsx
@@ -46,6 +46,7 @@ export default function ImageSection({ isEditing }: IProps) {
             alt="menu image"
             width={364}
             height={478}
+            unoptimized
             loading="lazy"
             className="h-full w-full object-cover"
           />

--- a/src/app/(main)/(owner)/[id]/@modal/menu/_components/DetailMenuModal/index.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/menu/_components/DetailMenuModal/index.tsx
@@ -9,6 +9,7 @@ import ImageSection from "./ImageSection";
 import ModalButton from "./ModalButton";
 import useMenuModalForm from "../../_hooks/useMenuModalForm";
 import useHandleMenuSubmit from "../../_hooks/useHandleMenuSubmit";
+import { TypeMenuForm } from "../../../../menu/_schema/menu.schema";
 
 const FormSection = dynamic(() => import("../FormSection"), { ssr: false });
 const OptionTemplate = dynamic(() => import("../OptionTemplate"), {
@@ -63,12 +64,13 @@ export default function DetailMenuModal({
     onError: () => setIsSubmitted(false),
   });
 
+  const onSubmit = (formData: unknown) =>
+    handleSubmit(formData as TypeMenuForm, handleAfterAction);
+
   return (
     <FormProvider {...form}>
       <form
-        onSubmit={form.handleSubmit((formData) =>
-          handleSubmit(formData, handleAfterAction)
-        )}
+        onSubmit={form.handleSubmit(onSubmit)}
         className="scrollbar-hide flex h-full w-full flex-col md:gap-5 lg:gap-8"
       >
         {/* 헤더 */}

--- a/src/app/(main)/(owner)/[id]/@modal/menu/_components/FormSection.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/menu/_components/FormSection.tsx
@@ -192,9 +192,12 @@ export default function FormSection({ isEditing, storeId, type }: IProps) {
                     className: "w-fit !rounded-[40px] h-7 px-3 text-xs",
                   },
                 }}
-                onClick={() =>
-                  isEditing ? form.setValue("spicy", key.length / 3) : null
-                }
+                onClick={() => {
+                  if (!isEditing) return;
+                  const current = form.watch("spicy");
+                  const next = key.length / 3;
+                  form.setValue("spicy", current === next ? 0 : next);
+                }}
                 commonClassName={
                   !isEditing
                     ? "hover:!bg-transparent !cursor-default hover:!text-current  pointer-events-none"

--- a/src/app/(main)/(owner)/[id]/@modal/menu/_components/FormSection.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/menu/_components/FormSection.tsx
@@ -1,5 +1,6 @@
 import { Separator } from "@radix-ui/react-dropdown-menu";
 import { Controller, useFormContext } from "react-hook-form";
+import { useEffect } from "react";
 import ResponsiveButton from "@/components/common/Button/ResponsiveButton";
 import Dropdown from "@/components/common/Dropdown";
 import Label from "@/components/common/Label";
@@ -25,6 +26,34 @@ export default function FormSection({ isEditing, storeId, type }: IProps) {
 
   const inputGap = "gap-1 lg:gap-2";
   const marginTop = "mt-2 lg:mt-4";
+
+  useEffect(() => {
+    form.register("label");
+    form.register("state");
+    form.register("spicy");
+    form.register("printEnabled");
+
+    if (form.getValues("label") == null) {
+      form.setValue("label", "DEFAULT");
+    }
+    if (form.getValues("state") == null) {
+      form.setValue("state", "DEFAULT");
+    }
+    if (form.getValues("spicy") == null) {
+      form.setValue("spicy", 1);
+    }
+    if (form.getValues("printEnabled") == null) {
+      form.setValue("printEnabled", true);
+    }
+  }, [form]);
+
+  const labelValue =
+    form.watch("label") ?? form.getValues("label") ?? "DEFAULT";
+  const stateValue =
+    form.watch("state") ?? form.getValues("state") ?? "DEFAULT";
+  const spicyValue = form.watch("spicy") ?? form.getValues("spicy") ?? 1;
+  const printEnabledValue =
+    form.watch("printEnabled") ?? form.getValues("printEnabled") ?? true;
 
   const getCategoryName = () =>
     data?.categories?.find((el) => el.categoryId === form.watch("category"))
@@ -108,7 +137,7 @@ export default function FormSection({ isEditing, storeId, type }: IProps) {
                 key={key}
                 type="button"
                 variant="outline"
-                color={form.watch("label") === key ? "primary" : "grey"}
+                color={labelValue === key ? "primary" : "grey"}
                 responsiveButtons={{
                   lg: {
                     buttonSize: "sm",
@@ -145,11 +174,7 @@ export default function FormSection({ isEditing, storeId, type }: IProps) {
                     key={key}
                     type="button"
                     variant="outline"
-                    color={
-                      form.watch("spicy") === key.length / 3
-                        ? "primary"
-                        : "grey"
-                    }
+                    color={spicyValue === key.length / 3 ? "primary" : "grey"}
                     responsiveButtons={{
                       lg: {
                         buttonSize: "sm",
@@ -183,7 +208,7 @@ export default function FormSection({ isEditing, storeId, type }: IProps) {
                 key={key}
                 type="button"
                 variant="outline"
-                color={form.watch("state") === key ? "primary" : "grey"}
+                color={stateValue === key ? "primary" : "grey"}
                 responsiveButtons={{
                   lg: {
                     buttonSize: "sm",
@@ -213,7 +238,7 @@ export default function FormSection({ isEditing, storeId, type }: IProps) {
           </span>
           <Switch
             className="h-5 w-10"
-            checked={form.watch("printEnabled")}
+            checked={printEnabledValue}
             onCheckedChange={(checked) =>
               form.setValue("printEnabled", checked)
             }

--- a/src/app/(main)/(owner)/[id]/@modal/menu/_components/FormSection.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/menu/_components/FormSection.tsx
@@ -160,45 +160,51 @@ export default function FormSection({ isEditing, storeId, type }: IProps) {
                       )
                     : null
                 }
+                commonClassName={
+                  !isEditing
+                    ? "hover:!bg-transparent !cursor-default hover:!text-current  pointer-events-none"
+                    : undefined
+                }
               >
                 {menuLabelTranslate[key as keyof typeof menuLabelTranslate]}
               </ResponsiveButton>
             ))}
           </div>
-          {type === "update" && (
-            <>
-              <Separator className="my-2 h-[2px] bg-gray-600" />
-              <div className="flex items-center gap-2">
-                {["🌶️", "🌶️🌶️", "🌶️🌶️🌶️"].map((key) => (
-                  <ResponsiveButton
-                    key={key}
-                    type="button"
-                    variant="outline"
-                    color={spicyValue === key.length / 3 ? "primary" : "grey"}
-                    responsiveButtons={{
-                      lg: {
-                        buttonSize: "sm",
-                        className: "w-fit !rounded-[40px]",
-                      },
-                      md: {
-                        buttonSize: "custom",
-                        className: "w-fit !rounded-[40px] h-7 px-3 text-xs",
-                      },
-                      sm: {
-                        buttonSize: "custom",
-                        className: "w-fit !rounded-[40px] h-7 px-3 text-xs",
-                      },
-                    }}
-                    onClick={() =>
-                      isEditing ? form.setValue("spicy", key.length / 3) : null
-                    }
-                  >
-                    {key}
-                  </ResponsiveButton>
-                ))}
-              </div>
-            </>
-          )}
+          <Separator className="my-2 h-[2px] bg-gray-600" />
+          <div className="flex items-center gap-2">
+            {["🌶️", "🌶️🌶️", "🌶️🌶️🌶️"].map((key) => (
+              <ResponsiveButton
+                key={key}
+                type="button"
+                variant="outline"
+                color={spicyValue === key.length / 3 ? "primary" : "grey"}
+                responsiveButtons={{
+                  lg: {
+                    buttonSize: "sm",
+                    className: "w-fit !rounded-[40px]",
+                  },
+                  md: {
+                    buttonSize: "custom",
+                    className: "w-fit !rounded-[40px] h-7 px-3 text-xs",
+                  },
+                  sm: {
+                    buttonSize: "custom",
+                    className: "w-fit !rounded-[40px] h-7 px-3 text-xs",
+                  },
+                }}
+                onClick={() =>
+                  isEditing ? form.setValue("spicy", key.length / 3) : null
+                }
+                commonClassName={
+                  !isEditing
+                    ? "hover:!bg-transparent !cursor-default hover:!text-current  pointer-events-none"
+                    : undefined
+                }
+              >
+                {key}
+              </ResponsiveButton>
+            ))}
+          </div>
         </div>
         <div className={cn("flex flex-col gap-2", marginTop)}>
           <Label>상태</Label>
@@ -225,6 +231,11 @@ export default function FormSection({ isEditing, storeId, type }: IProps) {
                 }}
                 onClick={() =>
                   isEditing ? form.setValue("state", key as MenuState) : null
+                }
+                commonClassName={
+                  !isEditing
+                    ? "hover:!bg-transparent !cursor-default hover:!text-current  pointer-events-none"
+                    : undefined
                 }
               >
                 {menuStateTranslate[key as keyof typeof menuStateTranslate]}

--- a/src/app/(main)/(owner)/[id]/@modal/menu/_components/OptionBox.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/menu/_components/OptionBox.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/common/Form";
 import Input from "@/components/common/Input";
 import Separator from "@/components/common/separator";
+import Switch from "@/components/common/Switch";
 import { TypeMenuForm } from "../../../menu/_schema/menu.schema";
 
 interface IProps {
@@ -26,109 +27,120 @@ export default function OptionBox({ type, index, isEditing }: IProps) {
   });
 
   return (
-    <div className="w-full rounded-[12px] border border-gray-600 p-3 lg:p-4">
-      <form>
-        <FormField
-          control={form.control}
-          name={`${type}.${index}.name`}
-          render={({ field }) => (
-            <FormItem className="w-full">
-              <FormControl>
-                <Input
-                  placeholder="옵션명을 입력해주세요."
-                  disabled={!isEditing}
-                  {...field}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
+    <div className="flex w-full cursor-default flex-col gap-4 rounded-[12px] border border-gray-600 p-3 lg:p-4">
+      <FormField
+        control={form.control}
+        name={`${type}.${index}.name`}
+        render={({ field }) => (
+          <FormItem className="w-full">
+            <FormControl>
+              <Input
+                placeholder="옵션명을 입력해주세요."
+                disabled={!isEditing}
+                {...field}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      <div className="flex items-center justify-between">
+        <span className="font-regular text-gray-0 text-xs lg:text-sm">
+          주방 프린터에 출력하기
+        </span>
+        <Switch
+          className="h-6 w-12"
+          checked={!!form.watch(`${type}.${index}.printEnabled` as const)}
+          onCheckedChange={(checked) =>
+            form.setValue(`${type}.${index}.printEnabled` as const, checked)
+          }
+          disabled={!isEditing}
         />
-        <Separator className="my-3 h-[1px] bg-[#eee] lg:my-4" />
-        <div className="flex flex-col gap-2 lg:gap-3">
-          {fields.map((field, i) => (
-            <div
-              key={field.id}
-              className="flex w-full items-center gap-1 lg:gap-2"
-            >
-              <FormField
-                control={form.control}
-                name={`${type}.${index}.menuOptions.${i}.name`}
-                render={({ field: nameField }) => (
-                  <FormItem className="flex w-full flex-1 lg:flex-[72]">
-                    <FormControl>
-                      <Input
-                        placeholder="하위 옵션명을 입력해주세요."
-                        disabled={!isEditing}
-                        {...nameField}
-                      />
-                    </FormControl>
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name={`${type}.${index}.menuOptions.${i}.price`}
-                render={({ field: priceField }) => (
-                  <FormItem className="relative flex w-full flex-1 lg:flex-[52.5]">
-                    <FormControl>
-                      <Input
-                        placeholder="ex. 33,000"
-                        className="!pr-10"
-                        type="number"
-                        disabled={!isEditing}
-                        {...priceField}
-                      />
-                    </FormControl>
-                    <span className="absolute top-1/2 right-4 translate-y-[-50%] text-[15px] font-medium text-[#7c7c7c]">
-                      원
-                    </span>
-                  </FormItem>
-                )}
-              />
-              {isEditing && (
-                <button
-                  type="button"
-                  className="flex p-1 lg:p-2"
-                  onClick={() => remove(i)}
-                >
-                  <Minus
-                    size={20}
-                    className="text-gray-300 md:h-4 md:w-4 lg:h-5 lg:w-5"
-                    strokeWidth={2}
-                  />
-                </button>
+      </div>
+      <Separator className="h-[1px] bg-gray-600" />
+      <div className="flex flex-col gap-2 lg:gap-3">
+        {fields.map((field, i) => (
+          <div
+            key={field.id}
+            className="flex w-full items-center gap-1 lg:gap-2"
+          >
+            <FormField
+              control={form.control}
+              name={`${type}.${index}.menuOptions.${i}.name`}
+              render={({ field: nameField }) => (
+                <FormItem className="flex w-full flex-1 lg:flex-[72]">
+                  <FormControl>
+                    <Input
+                      placeholder="하위 옵션명을 입력해주세요."
+                      disabled={!isEditing}
+                      {...nameField}
+                    />
+                  </FormControl>
+                </FormItem>
               )}
-            </div>
-          ))}
-          {isEditing && (
-            <ResponsiveButton
-              type="button"
-              color="grey"
-              responsiveButtons={{
-                lg: {
-                  buttonSize: "custom",
-                  className:
-                    "w-full h-8 rounded-[8px] text-center border-gray-600 text-sm text-gray-0",
-                },
-                md: {
-                  buttonSize: "custom",
-                  className:
-                    "w-full h-8 rounded-[8px] text-center border-gray-600 text-xs text-gray-0 flex gap-1",
-                },
-              }}
-              onClick={() => append({ name: "", price: 0 })}
-            >
-              하위 옵션 추가{" "}
-              <Plus
-                strokeWidth={1.5}
-                size={16}
-                className="md:h-3 md:w-3 lg:h-4 lg:w-4"
-              />
-            </ResponsiveButton>
-          )}
-        </div>
-      </form>
+            />
+            <FormField
+              control={form.control}
+              name={`${type}.${index}.menuOptions.${i}.price`}
+              render={({ field: priceField }) => (
+                <FormItem className="relative flex w-full flex-1 lg:flex-[52.5]">
+                  <FormControl>
+                    <Input
+                      placeholder="ex. 33,000"
+                      className="!pr-10"
+                      type="number"
+                      disabled={!isEditing}
+                      {...priceField}
+                    />
+                  </FormControl>
+                  <span className="absolute top-1/2 right-4 translate-y-[-50%] text-[15px] font-medium text-[#7c7c7c]">
+                    원
+                  </span>
+                </FormItem>
+              )}
+            />
+            {isEditing && (
+              <button
+                type="button"
+                className="flex p-1 lg:p-2"
+                onClick={() => remove(i)}
+              >
+                <Minus
+                  size={20}
+                  className="text-gray-300 md:h-4 md:w-4 lg:h-5 lg:w-5"
+                  strokeWidth={2}
+                />
+              </button>
+            )}
+          </div>
+        ))}
+        {isEditing && (
+          <ResponsiveButton
+            type="button"
+            color="grey"
+            responsiveButtons={{
+              lg: {
+                buttonSize: "custom",
+                className:
+                  "w-full h-8 rounded-[8px] text-center border-gray-600 text-sm text-gray-0",
+              },
+              md: {
+                buttonSize: "custom",
+                className:
+                  "w-full h-8 rounded-[8px] text-center border-gray-600 text-xs text-gray-0 flex gap-1",
+              },
+            }}
+            onClick={() => append({ name: "", price: 0 })}
+          >
+            하위 옵션 추가{" "}
+            <Plus
+              strokeWidth={1.5}
+              size={16}
+              className="md:h-3 md:w-3 lg:h-4 lg:w-4"
+            />
+          </ResponsiveButton>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/app/(main)/(owner)/[id]/@modal/menu/_components/OptionTemplate.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/menu/_components/OptionTemplate.tsx
@@ -58,46 +58,41 @@ export default function OptionTemplate({
         <div className="flex h-full flex-col gap-4">
           <div
             className={cn(
-              "flex flex-col gap-3 overflow-y-auto",
+              "scrollbar-hide flex cursor-pointer flex-col gap-3 overflow-y-auto",
               form.watch(type)?.length > 1
                 ? "lg:h-[calc(100%-95px)]"
                 : "lg:h-[calc(100%-40px)]"
             )}
           >
-            {form.watch(type)?.length > 0 ? (
-              form.watch(type)?.map((option, i) => (
-                <div
-                  key={option.name}
-                  className={cn(
-                    "flex gap-3",
-                    i > 0 ? "mt-3 lg:mt-4" : "",
-                    popupAction ? "items-center" : "item-start"
-                  )}
-                >
-                  <OptionBox type={type} index={i} isEditing={isEditing} />
-                  {popupAction && (
-                    <button
-                      type="button"
-                      className="center h-8 w-8 rounded-[8px] border border-gray-600"
-                    >
-                      <Icon
-                        iconKey={popupAction === "순서 변경" ? "move" : "trash"}
-                        size={18}
-                        className={
-                          popupAction === "순서 변경"
-                            ? "text-gray-300"
-                            : "text-gray-0"
-                        }
-                      />
-                    </button>
-                  )}
-                </div>
-              ))
-            ) : (
-              <div className="center flex-1 text-sm text-gray-300">
-                현재 등록된 필수 옵션이 없습니다.
+            {form.watch(type)?.map((_, i) => (
+              <div
+                // eslint-disable-next-line react/no-array-index-key
+                key={`${type}-${i}`}
+                className={cn(
+                  "flex gap-3",
+                  i > 0 ? "mt-3 lg:mt-4" : "",
+                  popupAction ? "items-center" : "item-start"
+                )}
+              >
+                <OptionBox type={type} index={i} isEditing={isEditing} />
+                {popupAction && (
+                  <button
+                    type="button"
+                    className="center h-8 w-8 rounded-[8px] border border-gray-600"
+                  >
+                    <Icon
+                      iconKey={popupAction === "순서 변경" ? "move" : "trash"}
+                      size={18}
+                      className={
+                        popupAction === "순서 변경"
+                          ? "text-gray-300"
+                          : "text-gray-0"
+                      }
+                    />
+                  </button>
+                )}
               </div>
-            )}
+            ))}
           </div>
 
           {/* 하단 버튼 고정 */}
@@ -113,7 +108,11 @@ export default function OptionTemplate({
               onClick={() =>
                 form.setValue(type, [
                   ...(form.watch(type) ?? []),
-                  { name: "", menuOptions: [{ name: "", price: 0 }] },
+                  {
+                    name: "",
+                    printEnabled: true,
+                    menuOptions: [{ name: "", price: 0 }],
+                  },
                 ])
               }
             >

--- a/src/app/(main)/(owner)/[id]/@modal/menu/_components/OptionTemplate.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/menu/_components/OptionTemplate.tsx
@@ -35,7 +35,7 @@ export default function OptionTemplate({
   return (
     <div
       className={cn(
-        "relative flex cursor-pointer flex-col gap-4 rounded-[12px] border border-gray-600 p-3 lg:rounded-[24px] lg:p-6",
+        "relative flex flex-col gap-4 rounded-[12px] border border-gray-600 p-3 lg:rounded-[24px] lg:p-6",
         props.isOpen ? "h-[calc(100%-57px-40px)]" : "",
         className
       )}
@@ -56,45 +56,55 @@ export default function OptionTemplate({
       />
       {props.isOpen ? (
         <div className="flex h-full flex-col gap-4">
-          <div
-            className={cn(
-              "scrollbar-hide flex cursor-pointer flex-col gap-3 overflow-y-auto",
-              form.watch(type)?.length > 1
-                ? "lg:h-[calc(100%-95px)]"
-                : "lg:h-[calc(100%-40px)]"
-            )}
-          >
-            {form.watch(type)?.map((_, i) => (
-              <div
-                // eslint-disable-next-line react/no-array-index-key
-                key={`${type}-${i}`}
-                className={cn(
-                  "flex gap-3",
-                  i > 0 ? "mt-3 lg:mt-4" : "",
-                  popupAction ? "items-center" : "item-start"
-                )}
-              >
-                <OptionBox type={type} index={i} isEditing={isEditing} />
-                {popupAction && (
-                  <button
-                    type="button"
-                    className="center h-8 w-8 rounded-[8px] border border-gray-600"
-                  >
-                    <Icon
-                      iconKey={popupAction === "순서 변경" ? "move" : "trash"}
-                      size={18}
-                      className={
-                        popupAction === "순서 변경"
-                          ? "text-gray-300"
-                          : "text-gray-0"
-                      }
-                    />
-                  </button>
-                )}
-              </div>
-            ))}
-          </div>
-
+          {isEditing && (
+            <div
+              className={cn(
+                "scrollbar-hide flex flex-col gap-3 overflow-y-auto",
+                isEditing ? "cursor-pointer" : ""
+              )}
+              style={{
+                height:
+                  form.watch(type)?.length > 1
+                    ? "calc(100% - 95px)"
+                    : "calc(100% - 40px)",
+              }}
+            >
+              {form.watch(type)?.map((_, i) => (
+                <div
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={`${type}-${i}`}
+                  className={cn(
+                    "flex gap-3",
+                    i > 0 ? "mt-3 lg:mt-4" : "",
+                    popupAction ? "items-center" : "item-start"
+                  )}
+                >
+                  <OptionBox type={type} index={i} isEditing={isEditing} />
+                  {popupAction && (
+                    <button
+                      type="button"
+                      className="center h-8 w-8 rounded-[8px] border border-gray-600"
+                    >
+                      <Icon
+                        iconKey={popupAction === "순서 변경" ? "move" : "trash"}
+                        size={18}
+                        className={
+                          popupAction === "순서 변경"
+                            ? "text-gray-300"
+                            : "text-gray-0"
+                        }
+                      />
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+          {!isEditing && form.watch(type)?.length === 0 && (
+            <div className="center h-full w-full text-sm">
+              {type.startsWith("required") ? "필수" : "선택"} 옵션이 없습니다.
+            </div>
+          )}
           {/* 하단 버튼 고정 */}
           {isEditing && (
             <ResponsiveButton

--- a/src/app/(main)/(owner)/[id]/@modal/menu/_hooks/useCategoryMove.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/menu/_hooks/useCategoryMove.tsx
@@ -106,6 +106,5 @@ export default function useCategoryMove(storeId: string) {
     resetMoves,
     initialRef,
     isSortSubmitting,
-    categories,
   };
 }

--- a/src/app/(main)/(owner)/[id]/@modal/menu/_hooks/useHandleMenuSubmit.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/menu/_hooks/useHandleMenuSubmit.tsx
@@ -34,6 +34,26 @@ export default function useHandleMenuSubmit({
   ) => {
     onSetIsSubmitted(true);
 
+    const hasGroupWithNameButNoOptions = (
+      groups?: TypeMenuForm["requiredOptions"]
+    ) =>
+      (groups ?? []).some((g) => {
+        const hasName = (g?.name?.trim() ?? "") !== "";
+        const numValidOptions = (g?.menuOptions ?? []).filter(
+          (opt) => (opt?.name?.trim() ?? "") !== ""
+        ).length;
+        return hasName && numValidOptions === 0;
+      });
+
+    if (
+      hasGroupWithNameButNoOptions(data.requiredOptions) ||
+      hasGroupWithNameButNoOptions(data.optionalOptions)
+    ) {
+      alert("하위 옵션을 1개 이상 입력해주세요.");
+      onSetIsSubmitted(false);
+      return;
+    }
+
     const { request } = formToRequest(data);
 
     if (type === "create") {

--- a/src/app/(main)/(owner)/[id]/@modal/menu/_hooks/useHandleMenuSubmit.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/menu/_hooks/useHandleMenuSubmit.tsx
@@ -49,6 +49,7 @@ export default function useHandleMenuSubmit({
       hasGroupWithNameButNoOptions(data.requiredOptions) ||
       hasGroupWithNameButNoOptions(data.optionalOptions)
     ) {
+      // eslint-disable-next-line no-alert
       alert("하위 옵션을 1개 이상 입력해주세요.");
       onSetIsSubmitted(false);
       return;

--- a/src/app/(main)/(owner)/[id]/@modal/menu/_hooks/useMenuForm.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/menu/_hooks/useMenuForm.tsx
@@ -63,11 +63,10 @@ export const formToRequest = (form: TypeMenuForm) => {
       name: form.name,
       description: form.description,
       price: Number(String(form.price ?? "").replace(/,/g, "") || 0),
-      spicy: form.spicy,
+      spicy: (form.spicy ?? 1) as number,
       state: form.state,
       label: form.label,
       printEnabled: form.printEnabled,
-      image: form.imgString,
       menuOptionGroups,
     },
   };

--- a/src/app/(main)/(owner)/[id]/@modal/menu/_hooks/useMenuForm.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/menu/_hooks/useMenuForm.tsx
@@ -28,11 +28,11 @@ export const formToRequest = (form: TypeMenuForm) => {
   if (form.requiredOptions?.length > 0) {
     menuOptionGroups.push(
       ...form.requiredOptions
-        .filter((group) => group.name.trim() !== "")
+        .filter((group) => (group?.name?.trim() ?? "") !== "")
         .map((group) => ({
-          name: group.name,
+          name: group.name as string,
           type: "MANDATORY" as MenuOptionType,
-          printEnabled: true,
+          printEnabled: group.printEnabled ?? true,
           menuOptions: group.menuOptions.filter(
             (opt) => opt.name.trim() !== ""
           ),
@@ -44,11 +44,11 @@ export const formToRequest = (form: TypeMenuForm) => {
   if (form.optionalOptions?.length > 0) {
     menuOptionGroups.push(
       ...form.optionalOptions
-        .filter((group) => group.name.trim() !== "")
+        .filter((group) => (group?.name?.trim() ?? "") !== "")
         .map((group) => ({
-          name: group.name,
+          name: group.name as string,
           type: "OPTIONAL" as MenuOptionType,
-          printEnabled: true,
+          printEnabled: group.printEnabled ?? true,
           menuOptions: group.menuOptions.filter(
             (opt) => opt.name.trim() !== ""
           ),

--- a/src/app/(main)/(owner)/[id]/@modal/menu/category/add/page.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/menu/category/add/page.tsx
@@ -29,10 +29,7 @@ export default function Page() {
     initialRef,
     resetMoves,
     isSortSubmitting,
-    categories,
   } = useCategoryMove(storeId);
-
-  console.log(categories);
 
   const update = categoryQueries.useUpdateCategory();
   const add = categoryQueries.useAddCategory();

--- a/src/app/(main)/(owner)/[id]/@modal/menu/create/layout.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/menu/create/layout.tsx
@@ -3,7 +3,7 @@ import ClientRefWrapper from "../_components/Wrapper";
 
 export default async function Layout({ children }: PropsWithChildren) {
   return (
-    <ClientRefWrapper className="md:h-[621px] md:w-[912px] lg:h-[832px] lg:w-[1344px]">
+    <ClientRefWrapper className="aspect-[1344/832] md:h-auto md:min-w-[1000px] lg:h-[832px] lg:w-[1344px]">
       {children}
     </ClientRefWrapper>
   );

--- a/src/app/(main)/(owner)/[id]/menu/[menuId]/category/[categoryId]/page.tsx
+++ b/src/app/(main)/(owner)/[id]/menu/[menuId]/category/[categoryId]/page.tsx
@@ -1,24 +1,5 @@
-"use client";
-
-import { useStoreContext } from "@/providers/storeProvider";
-import { useRouter, useParams, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import MenuList from "../../../_components/MenuList";
 
 export default function Page() {
-  const navigate = useRouter();
-  const params = useParams();
-  const searchParams = useSearchParams();
-
-  const menuId = params?.menuId;
-  const categoryId = searchParams.get("categoryId");
-
-  const { storeId } = useStoreContext();
-
-  useEffect(() => {
-    if (categoryId) {
-      navigate.replace(`/${storeId}/menu/${menuId}?categoryId=${categoryId}`);
-    }
-  }, [menuId, categoryId, navigate, storeId]);
-
-  return null;
+  return <MenuList />;
 }

--- a/src/app/(main)/(owner)/[id]/menu/_components/MenuCard.tsx
+++ b/src/app/(main)/(owner)/[id]/menu/_components/MenuCard.tsx
@@ -46,6 +46,7 @@ export default function MenuCard({
             fill
             className="object-cover"
             loading="eager"
+            unoptimized
             priority
             sizes="(max-width: 768px) 100vw, 300px"
           />

--- a/src/app/(main)/(owner)/[id]/menu/_schema/menu.schema.ts
+++ b/src/app/(main)/(owner)/[id]/menu/_schema/menu.schema.ts
@@ -18,6 +18,7 @@ const schema = z.object({
   requiredOptions: z.array(
     z.object({
       name: z.string(),
+      printEnabled: z.boolean().default(true).optional(),
       menuOptions: z.array(
         z.object({
           name: z.string(),
@@ -29,6 +30,7 @@ const schema = z.object({
   optionalOptions: z.array(
     z.object({
       name: z.string(),
+      printEnabled: z.boolean().default(true).optional(),
       menuOptions: z.array(
         z.object({
           name: z.string(),

--- a/src/app/(main)/(owner)/[id]/menu/_schema/menu.schema.ts
+++ b/src/app/(main)/(owner)/[id]/menu/_schema/menu.schema.ts
@@ -17,7 +17,7 @@ const schema = z.object({
   printEnabled: z.boolean(),
   requiredOptions: z.array(
     z.object({
-      name: z.string(),
+      name: z.string().optional(),
       printEnabled: z.boolean().default(true).optional(),
       menuOptions: z.array(
         z.object({
@@ -29,7 +29,7 @@ const schema = z.object({
   ),
   optionalOptions: z.array(
     z.object({
-      name: z.string(),
+      name: z.string().optional(),
       printEnabled: z.boolean().default(true).optional(),
       menuOptions: z.array(
         z.object({

--- a/src/app/(main)/(owner)/[id]/menu/_schema/menu.schema.ts
+++ b/src/app/(main)/(owner)/[id]/menu/_schema/menu.schema.ts
@@ -11,7 +11,7 @@ const schema = z.object({
   price: z.string({ message: "가격을 입력해주세요." }).regex(/^[0-9,]+$/, {
     message: "가격은 숫자와 콤마만 입력할 수 있습니다.",
   }),
-  spicy: z.number().min(1).max(3),
+  spicy: z.number().min(1).max(3).nullable(),
   state: z.enum(["DEFAULT", "HIDE", "SOLD_OUT"]).optional(),
   label: z.enum(["BEST", "NEW", "DEFAULT", "RECOMMEND"]).optional(),
   printEnabled: z.boolean(),

--- a/src/app/(main)/(owner)/[id]/menu/_schema/menu.schema.ts
+++ b/src/app/(main)/(owner)/[id]/menu/_schema/menu.schema.ts
@@ -11,7 +11,7 @@ const schema = z.object({
   price: z.string({ message: "가격을 입력해주세요." }).regex(/^[0-9,]+$/, {
     message: "가격은 숫자와 콤마만 입력할 수 있습니다.",
   }),
-  spicy: z.number().min(1).max(3).nullable(),
+  spicy: z.number().min(1).max(3).nullable().default(null),
   state: z.enum(["DEFAULT", "HIDE", "SOLD_OUT"]).optional(),
   label: z.enum(["BEST", "NEW", "DEFAULT", "RECOMMEND"]).optional(),
   printEnabled: z.boolean(),
@@ -75,5 +75,5 @@ export const menuListSchema = z.object({
   ),
 });
 
-export type TypeMenuForm = z.infer<typeof menuFormSchema>;
-export type TypeMenuList = z.infer<typeof menuListSchema>;
+export type TypeMenuForm = z.input<typeof menuFormSchema>;
+export type TypeMenuList = z.input<typeof menuListSchema>;

--- a/src/app/(main)/(owner)/[id]/store/_components/modals/PhotoForBusiness.tsx
+++ b/src/app/(main)/(owner)/[id]/store/_components/modals/PhotoForBusiness.tsx
@@ -42,6 +42,7 @@ export default function PhotoForBusiness({
             width={380}
             height={457}
             className="h-full rounded-[16px] border border-gray-600 md:h-[260px] md:w-[216px] lg:h-[437px] lg:w-[360px]"
+            unoptimized
           />
         )}
         <input

--- a/src/app/(main)/admin/@modal/stores/[registrationId]/page.tsx
+++ b/src/app/(main)/admin/@modal/stores/[registrationId]/page.tsx
@@ -108,6 +108,7 @@ export default function Page() {
                       alt="사업자 등록증"
                       width={381}
                       height={458}
+                      unoptimized
                       className="rounded-[16px] border border-gray-600 object-cover lg:h-[458px] lg:w-[381px]"
                     />
                   </div>

--- a/src/app/(public)/menus/_components/MobileMenuCard.tsx
+++ b/src/app/(public)/menus/_components/MobileMenuCard.tsx
@@ -23,6 +23,7 @@ export default function MobileMenuCard({
             alt="menu"
             width={96}
             height={96}
+            unoptimized
             className="h-full w-full object-cover"
           />
         </div>

--- a/src/components/common/Switch.tsx
+++ b/src/components/common/Switch.tsx
@@ -20,39 +20,40 @@ const Switch = forwardRef<
   ElementRef<typeof SwitchPrimitives.Root>,
   SwitchProps
 >(({ className, width = 48, height = 24, thumbSize = 16, ...props }, ref) => {
-  const checkedTranslate = useMemo(() => {
-    const padding = (height - thumbSize) / 2;
-    return width - thumbSize - padding;
-  }, [width, height, thumbSize]);
-
-  const uncheckedTranslate = useMemo(
+  const containerPadding = useMemo(
     () => (height - thumbSize) / 2,
     [height, thumbSize]
+  );
+
+  const travelX = useMemo(
+    () => width - thumbSize - containerPadding * 2,
+    [width, thumbSize, containerPadding]
   );
 
   return (
     <SwitchPrimitives.Root
       className={cn(
-        "peer focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:border-primary inline-flex h-[24px] w-[48px] shrink-0 items-center rounded-full border transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed data-[state=checked]:bg-white disabled:data-[state=checked]:border-transparent disabled:data-[state=checked]:bg-[#F2202030] data-[state=unchecked]:border-gray-600 data-[state=unchecked]:bg-gray-600",
-        props.disabled ? "cursor-default" : "cursor-pointer",
+        "peer focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:border-primary inline-flex h-[24px] w-[48px] shrink-0 items-center justify-start rounded-full border transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed data-[state=checked]:bg-white disabled:data-[state=checked]:border-transparent disabled:data-[state=checked]:bg-[#F2202030] data-[state=unchecked]:border-gray-600 data-[state=unchecked]:bg-gray-600",
         className
       )}
       style={{
         width,
         height,
+        padding: containerPadding,
+        ["--travel-x" as any]: `${travelX}px`,
+        cursor: props.disabled ? "default" : "pointer",
       }}
       {...props}
       ref={ref}
     >
       <SwitchPrimitives.Thumb
         className={cn(
-          "pointer-events-none block rounded-full ring-0 transition-transform",
+          "pointer-events-none block translate-x-0 rounded-full ring-0 transition-transform duration-200 ease-out data-[state=checked]:translate-x-[var(--travel-x)]",
           "data-[state=checked]:bg-primary bg-white data-[disabled]:data-[state=checked]:bg-white"
         )}
         style={{
           width: thumbSize,
           height: thumbSize,
-          transform: `translateX(${props.checked ? checkedTranslate : uncheckedTranslate}px)`,
         }}
       />
     </SwitchPrimitives.Root>


### PR DESCRIPTION
## 🚀연관된 이슈
- #이슈 번호

## 📝작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요

- [SKEU-185] 메뉴 등록 시 상태, 태그 디폴트값
  - 변경 전: 상태, 태그의 기본 값이 표시되지 않음
  - 변경 후: 상태, 태그의 기본 값을 확실히 고정함
- [SKEU-188] 메뉴 이미지 안 보임
  - 변경 전: Next/Image 사용 시 자동으로 최적화를 진행해 cdn을 사용할 수 없음
  - 변경 후: cdn이 필요한 이미지에는 unoptimized 옵션을 추가해 추가적인 최적화 작업을 하지 않도록 설정
- [SKEU-192] 메뉴 필수 옵션 등록
  - 변경 전: 리렌더링 문제(key)로 입력이 지속되지 않음
  - 변경 후: key 값 변경으로 해결
- [SKEU-193] 필수 옵션, 선택 옵션 - 주방 프린터 출력 여부
  - 변경 전: 없음
  - 변경 후: 디자인 추가
- [SKEU-194] 하위 옵션명 미가입시 안내문구
  - 변경 전: 옵션에 이름만 있어도 submit이 진행됨
  - 변경 후: schema에서 진행하려고 했지만, 정확한 연관관계에 의한 에러 문구를 출력하지 못함. >> 따라서 submit할 때 조건을 확인하여 하위 옵션이 없을 경우 alert 출력
- [SKEU-195] 고추 아이콘
  - 변경 전: 상세 메뉴 모달에만 spicy 이모티콘 표시
  - 변경 후: 메뉴 생성 시에도 spicy 이모티콘 표시, 토글화

## 📷스크린샷 (선택)
<img width="2352" height="1347" alt="스크린샷 2025-08-17 오후 3 15 16" src="https://github.com/user-attachments/assets/c96c21b3-73db-4432-a25d-261e469c6340" />
<img width="2352" height="1347" alt="스크린샷 2025-08-17 오후 3 15 08" src="https://github.com/user-attachments/assets/1257f3cf-6740-4d58-8cee-d27bf8db2cfa" />


## 💬리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

[SKEU-185]: https://everyonewaiter.atlassian.net/browse/SKEU-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SKEU-188]: https://everyonewaiter.atlassian.net/browse/SKEU-188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SKEU-192]: https://everyonewaiter.atlassian.net/browse/SKEU-192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SKEU-193]: https://everyonewaiter.atlassian.net/browse/SKEU-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SKEU-194]: https://everyonewaiter.atlassian.net/browse/SKEU-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SKEU-195]: https://everyonewaiter.atlassian.net/browse/SKEU-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ