### PR TITLE
fix: QA 메뉴 순서 변경 및 삭제 구현

### DIFF
--- a/src/app/(main)/(owner)/[id]/@modal/device/[deviceId]/page.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/device/[deviceId]/page.tsx
@@ -35,12 +35,7 @@ export default function DeviceInfoModal() {
 
   return (
     <Form {...form}>
-      <form
-        className="flex flex-col gap-4"
-        // onSubmit={form.handleSubmit((_data) =>
-        //   submitHandler(update, _data, { storeId, deviceId })
-        // )}
-      >
+      <form className="flex flex-col gap-4">
         <LabeledInput form={form} name="name" label="기기 이름" />
         <LabeledInput form={form} name="createdAt" label="등록일시" disabled />
         <LabeledInput form={form} name="state" label="상태" disabled />

--- a/src/app/(main)/(owner)/[id]/@modal/menu/_components/OptionComponent.tsx
+++ b/src/app/(main)/(owner)/[id]/@modal/menu/_components/OptionComponent.tsx
@@ -7,7 +7,6 @@ import Popup from "./Popup";
 
 interface IProps {
   title: string;
-  // onSetShowInfo: (value: boolean) => void;
   onSetPopupAction: (value: string) => void;
   popupAction: string;
   isOpen: boolean;
@@ -16,19 +15,12 @@ interface IProps {
 
 export default function OptionComponent({
   title,
-  // onSetShowInfo,
   onSetPopupAction,
   popupAction,
   isOpen,
   isEditing,
 }: IProps) {
-  // const infoRef = useRef<HTMLDivElement>(null);
   const [showPopup, setShowPopup] = useState(false);
-
-  // useOutsideClick({
-  //   ref: infoRef,
-  //   handler: () => onSetShowInfo(false),
-  // });
 
   return (
     <div className="relative flex items-center justify-between">
@@ -38,14 +30,7 @@ export default function OptionComponent({
           iconKey="information"
           size={24}
           className="text-gray-0 h-5 w-5 lg:h-6 lg:w-6"
-          // onMouseEnter={() => onSetShowInfo(true)}
-          // onMouseLeave={() => onSetShowInfo(false)}
         />
-        {/* {showInfo && (
-          <FloatingInfo ref={infoRef}>
-            {`첫번째 옵션 상세가 기본값으로 설정됩니다.\n순서변경 아이콘 클릭 시 옵션명 및 옵션상세의 순서를 변경할 수 있습니다.`}
-          </FloatingInfo>
-        )} */}
       </div>
 
       {isOpen && isEditing && (

--- a/src/app/(main)/(owner)/[id]/device/_components/_template/DevicePage.tsx
+++ b/src/app/(main)/(owner)/[id]/device/_components/_template/DevicePage.tsx
@@ -204,11 +204,7 @@ export default function DevicePage() {
                 />
                 <span>{index + 1}</span>
               </div>
-              <MobileTable
-                className="z-10"
-                key={item.deviceId}
-                // onClick={() => handleModalOpen(item.deviceId)}
-              >
+              <MobileTable className="z-10" key={item.deviceId}>
                 <TableBody className="flex flex-col">
                   <MobileTableRow>
                     <MobileTableHead>이름</MobileTableHead>

--- a/src/app/(main)/(owner)/[id]/menu/[menuId]/category/[categoryId]/layout.tsx
+++ b/src/app/(main)/(owner)/[id]/menu/[menuId]/category/[categoryId]/layout.tsx
@@ -9,11 +9,9 @@ import { categoryKeys, menuKeys } from "../../../_queries/keys";
 export default async function Layout({
   children,
   params,
-  // modal,
 }: {
   children: React.ReactNode;
   params: Promise<{ id: string }>;
-  // modal?: React.ReactNode;
 }) {
   const queryClient = getQueryClient();
   const { id } = await params;
@@ -30,10 +28,7 @@ export default async function Layout({
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <div className="relative flex min-h-screen flex-col">
-        {children}
-        {/* {modal} */}
-      </div>
+      <div className="relative flex min-h-screen flex-col">{children}</div>
     </HydrationBoundary>
   );
 }

--- a/src/app/(main)/(owner)/[id]/menu/_api/menu.api.ts
+++ b/src/app/(main)/(owner)/[id]/menu/_api/menu.api.ts
@@ -171,12 +171,12 @@ export const deleteMenu = async ({
 };
 
 export const deleteMultipleMenus = async ({
+  menuIds,
   storeId,
-  body,
-}: PropsWithStoreId<{ body: { menuId: string }[] }>) => {
+}: PropsWithStoreId<{ menuIds: string[] }>) => {
   const response = await instance.post(
     `${API_PATH.stores}/${storeId}/menus/delete`,
-    body
+    { menuIds }
   );
   return response.data;
 };

--- a/src/app/(main)/(owner)/[id]/menu/_components/DeleteAlert.tsx
+++ b/src/app/(main)/(owner)/[id]/menu/_components/DeleteAlert.tsx
@@ -17,19 +17,32 @@ export default function DeleteAlert({
   const remove = menuQueries.useDeleteMenu(storeId);
   const multiRemove = menuQueries.useMultiDelete(storeId);
 
+  console.log(selected);
+
   return (
     <Alert
       onClose={close}
       onAction={() => {
         const fn =
-          selected?.length > 1
-            ? () => multiRemove.mutate({ body: selected, storeId })
+          selected?.length >= 2
+            ? () =>
+                multiRemove.mutate(
+                  { menuIds: selected.map((el) => el.menuId), storeId },
+                  {
+                    onSuccess: () => close(),
+                  }
+                )
             : () =>
-                remove.mutate({
-                  categoryId,
-                  storeId,
-                  menuId: selected[0].menuId,
-                });
+                remove.mutate(
+                  {
+                    categoryId,
+                    storeId,
+                    menuId: selected[0].menuId,
+                  },
+                  {
+                    onSuccess: () => close(),
+                  }
+                );
 
         fn();
       }}

--- a/src/app/(main)/(owner)/[id]/menu/_components/HeaderButton.tsx
+++ b/src/app/(main)/(owner)/[id]/menu/_components/HeaderButton.tsx
@@ -41,16 +41,11 @@ export default function HeaderButton({
     ));
   };
 
-  const handleSaveSort = () => {
-    onSaveSort();
-    onSetChangeSort(false);
-  };
-
   return (
     <div className="flex items-center justify-end gap-4 lg:gap-6">
       {changeSort ? (
         <div className="flex items-center gap-2">
-          <div className="text-primary font-regular hidden h-9 items-center justify-center rounded-[8px] bg-[rgba(242,32,32,0.04)] px-4 text-sm lg:flex">
+          <div className="text-primary font-regular hidden h-9 items-center justify-center rounded-[8px] bg-[rgba(242,32,32,0.04)] px-4 text-sm md:flex">
             메뉴의 순서 변경은 메뉴를 꾹 누르신 후, 원하시는 자리로 메뉴를
             이동해주세요
           </div>
@@ -61,7 +56,7 @@ export default function HeaderButton({
               md: { buttonSize: "sm" },
               sm: { buttonSize: "sm" },
             }}
-            onClick={handleSaveSort}
+            onClick={onSaveSort}
           >
             저장
           </ResponsiveButton>

--- a/src/app/(main)/(owner)/[id]/menu/_components/MenuList.tsx
+++ b/src/app/(main)/(owner)/[id]/menu/_components/MenuList.tsx
@@ -17,9 +17,15 @@ export default function MenuList() {
   const { storeId } = useStoreContext();
   const { isSelected, toggle, selectedCards } = useSelectedCard();
   const { active, categories, setActive } = useActiveCategory(storeId);
-  const { handleSortSave, handleDragEnd } = useMenuSort(storeId, active);
+  const { form, handleSortSave, handleDragEnd } = useMenuSort(storeId, active);
 
   const [changeSort, setChangeSort] = useState(false);
+
+  const getBorderClass = (categoryId: string) => {
+    if (changeSort) return "border-gray-300 bg-transparent";
+    if (active === categoryId) return "border-black";
+    return "border-gray-300";
+  };
 
   return (
     <div className="flex flex-col pb-2 md:pt-4 lg:pt-6">
@@ -44,6 +50,7 @@ export default function MenuList() {
             }}
             onClick={() => navigate.push(`/${storeId}/menu/category/add`)}
             aria-label="카테고리 등록 및 수정"
+            disabled={changeSort}
           >
             <SettingsIcon size={18} strokeWidth={1.5} />
           </ResponsiveButton>
@@ -60,10 +67,9 @@ export default function MenuList() {
                 md: { buttonSize: "sm" },
                 sm: { buttonSize: "sm" },
               }}
-              commonClassName={
-                active === cat.categoryId ? "border-black" : "border-gray-300"
-              }
+              commonClassName={getBorderClass(cat.categoryId)}
               onClick={() => setActive(cat.categoryId)}
+              disabled={changeSort}
             >
               {cat.name}
             </ResponsiveButton>
@@ -74,7 +80,7 @@ export default function MenuList() {
           categoryId={active}
           changeSort={changeSort}
           onSetChangeSort={setChangeSort}
-          onSaveSort={handleSortSave}
+          onSaveSort={() => handleSortSave(() => setChangeSort(false))}
         />
       </div>
       <RenderMenu
@@ -83,6 +89,7 @@ export default function MenuList() {
         isSelected={isSelected}
         toggle={toggle}
         handleDragEnd={handleDragEnd}
+        sortedMenus={form.watch("menus")}
       />
     </div>
   );

--- a/src/app/(main)/(owner)/[id]/menu/_components/RenderMenu.tsx
+++ b/src/app/(main)/(owner)/[id]/menu/_components/RenderMenu.tsx
@@ -7,7 +7,9 @@ import { useMediaQuery } from "react-responsive";
 import DashedBorder from "@/components/DashedBorder";
 import { useStoreContext } from "@/providers/storeProvider";
 import Spinner from "@/components/common/Spinner";
+import { rectSortingStrategy } from "@/components/dnd";
 import { Skeleton } from "@/components/common/Skeleton/Skeleton";
+import { TypeMenuList } from "../_schema/menu.schema";
 import { menuQueries } from "../_queries/useMenu";
 import MenuCard from "./MenuCard";
 
@@ -27,6 +29,7 @@ interface IProps {
   isSelected: (value: { menuId: string }) => boolean;
   toggle: (value: { menuId: string }) => void;
   handleDragEnd: ({ active, over }: any) => void;
+  sortedMenus?: TypeMenuList["menus"];
 }
 
 export default function RenderMenu({
@@ -35,6 +38,7 @@ export default function RenderMenu({
   isSelected,
   toggle,
   handleDragEnd,
+  sortedMenus,
 }: IProps) {
   const navigate = useRouter();
   const isMobile = useMediaQuery({ query: "(max-width: 767px)" });
@@ -49,40 +53,43 @@ export default function RenderMenu({
     <div className="mt-4 mb-4 flex flex-1 flex-col lg:mt-6 lg:mb-0">
       <div className="flex-1">
         <div className="grid grid-cols-3 gap-4 md:grid-cols-5 md:gap-x-[10px] md:gap-y-[16px] lg:gap-x-[32px] lg:gap-y-[40px]">
-          <button
-            type="button"
-            className="aspect-[329/440] h-full"
-            onClick={() =>
-              navigate.push(
-                `/${storeId}/menu/create?categoryId=${categoryId}&hideModal=${isMobile}`
-              )
-            }
-          >
-            <DashedBorder
-              layoutClassName="bg-gray-700 cursor-pointer h-full"
-              radius={{
-                lg: 24,
-                md: 12,
-                sm: 15,
-              }}
-            >
-              <PlusIcon strokeWidth={1.5} />
-              <span className="text-base">메뉴 추가</span>
-            </DashedBorder>
-          </button>
-          {data && changeSort && (
+          {sortedMenus && changeSort && (
             <Sortable
-              items={data?.menus?.map((item) => item.menuId)!}
+              items={sortedMenus.map((item) => item.menuId!)}
               onDragEnd={handleDragEnd}
+              sortingStrategy={rectSortingStrategy}
             >
-              {data?.menus?.map((item) => (
+              {sortedMenus.map((item) => (
                 <SortableItem
-                  key={item.menuId}
+                  key={item.menuId!}
                   item={item}
-                  onClick={() => navigate.push(handleNavigate(item.menuId))}
+                  onClick={() => navigate.push(handleNavigate(item.menuId!))}
                 />
               ))}
             </Sortable>
+          )}
+          {!changeSort && (
+            <button
+              type="button"
+              className="aspect-[329/440] h-full"
+              onClick={() =>
+                navigate.push(
+                  `/${storeId}/menu/create?categoryId=${categoryId}&hideModal=${isMobile}`
+                )
+              }
+            >
+              <DashedBorder
+                layoutClassName="bg-gray-700 cursor-pointer h-full"
+                radius={{
+                  lg: 24,
+                  md: 12,
+                  sm: 15,
+                }}
+              >
+                <PlusIcon strokeWidth={1.5} />
+                <span className="text-base">메뉴 추가</span>
+              </DashedBorder>
+            </button>
           )}
           {data &&
             !changeSort &&

--- a/src/app/(main)/(owner)/[id]/menu/_components/SortableItem.tsx
+++ b/src/app/(main)/(owner)/[id]/menu/_components/SortableItem.tsx
@@ -1,28 +1,41 @@
 import { useSortable, CSS } from "@/components/dnd/index";
 import MenuCard from "./MenuCard";
+import { TypeMenuList } from "../_schema/menu.schema";
+
+type SortableMenu = Menu | TypeMenuList["menus"][number];
 
 interface IProps {
-  item: Menu;
+  item: SortableMenu;
   onClick: () => void;
 }
 
 export default function SortableItem({ item, onClick }: IProps) {
   const { attributes, listeners, setNodeRef, transform, transition } =
-    useSortable({ id: item.menuId });
+    useSortable({ id: (item as any).menuId });
 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
   };
 
+  const normalized = {
+    ...(item as any),
+    price:
+      typeof (item as any).price === "string"
+        ? Number(String((item as any).price).replace(/,/g, "") || 0)
+        : (item as any).price,
+    categoryId: (item as any).categoryId ?? (item as any).category,
+  } as unknown as Menu;
+
   return (
     <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
       <MenuCard
-        {...item}
+        {...(normalized as Menu)}
         onToggle={() => null}
         isSelected={false}
         hideSelect
         onClick={onClick}
+        className="animate-wiggle"
       />
     </div>
   );

--- a/src/app/(main)/(owner)/[id]/menu/_hooks/useMenuSort.tsx
+++ b/src/app/(main)/(owner)/[id]/menu/_hooks/useMenuSort.tsx
@@ -2,10 +2,13 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { arrayMove } from "@/components/dnd/index";
+import getQueryClient from "@/app/get-query-client";
+import { menuKeys } from "../_queries/keys";
 import { menuQueries } from "../_queries/useMenu";
 import { menuListSchema, TypeMenuList } from "../_schema/menu.schema";
 
 export function useMenuSort(storeId: string, categoryId: string) {
+  const queryClient = getQueryClient();
   const initialRef = useRef<TypeMenuList["menus"]>([]);
   const form = useForm<TypeMenuList>({
     mode: "onChange",
@@ -34,6 +37,7 @@ export function useMenuSort(storeId: string, categoryId: string) {
     const oldIndex = list.findIndex((i) => i.menuId === active.id);
     const newIndex = list.findIndex((i) => i.menuId === over.id);
     if (oldIndex < 0 || newIndex < 0) return;
+    if (oldIndex === newIndex) return;
 
     const moved = arrayMove(list, oldIndex, newIndex);
     form.setValue("menus", moved);
@@ -59,10 +63,47 @@ export function useMenuSort(storeId: string, categoryId: string) {
       );
   }, [menus?.menus, setInit]);
 
-  const handleSortSave = async () => {
-    await Promise.all(
-      pendingMoves.map((moveData) => move.mutateAsync({ storeId, ...moveData }))
-    );
+  const handleSortSave = async (successHandler: () => void) => {
+    const finalList = form.watch("menus");
+    if (!finalList || finalList.length === 0) return;
+
+    const simulated = initialRef.current.map((m) => m.menuId!);
+
+    const movesToApply: {
+      sourceId: string;
+      targetId: string;
+      where: "NEXT";
+    }[] = [];
+
+    for (let i = 1; i < finalList.length; i += 1) {
+      const sourceId = finalList[i].menuId!;
+      const targetId = finalList[i - 1].menuId!;
+
+      const srcIdx = simulated.indexOf(sourceId);
+      const tgtIdx = simulated.indexOf(targetId);
+      const shouldApply =
+        srcIdx !== -1 && tgtIdx !== -1 && srcIdx !== tgtIdx + 1;
+      if (shouldApply) {
+        movesToApply.push({ sourceId, targetId, where: "NEXT" });
+        simulated.splice(srcIdx, 1);
+        const newIdx = simulated.indexOf(targetId) + 1;
+        simulated.splice(newIdx, 0, sourceId);
+      }
+    }
+
+    if (movesToApply.length === 0) return;
+
+    for (let i = 0; i < movesToApply.length; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await move.mutateAsync({ storeId, ...movesToApply[i] });
+    }
+
+    initialRef.current = finalList;
+    setPendingMoves([]);
+    queryClient.invalidateQueries({
+      queryKey: menuKeys.category(storeId, categoryId),
+    });
+    successHandler();
   };
 
   return {

--- a/src/app/(main)/admin/users/_components/UsersTable.tsx
+++ b/src/app/(main)/admin/users/_components/UsersTable.tsx
@@ -48,7 +48,6 @@ export default function UsersTable({ data }: IProps) {
             <UsersTableRow
               key={item.accountId.toString()}
               {...item}
-              // openModal={() => handleOpenModal(item.accountId)}
               openModal={() => navigate.push(`/admin/users/${item.accountId}`)}
             />
           ))}
@@ -59,7 +58,6 @@ export default function UsersTable({ data }: IProps) {
           <MobileTable
             key={item.accountId}
             className="z-10"
-            // onClick={() => handleOpenModal(item.accountId)}
             onClick={() => navigate.push(`/admin/users/${item.accountId}`)}
           >
             <TableBody className="flex flex-col">

--- a/src/app/(main)/admin/users/layout.tsx
+++ b/src/app/(main)/admin/users/layout.tsx
@@ -1,15 +1,11 @@
 import { PropsWithChildren } from "react";
 import PageTitle from "../../_components/PageTitle/PageTitle";
 
-export default function Layout({
-  children,
-  // modal,
-}: PropsWithChildren) {
+export default function Layout({ children }: PropsWithChildren) {
   return (
     <div className="h-full">
       <PageTitle initialTitle="회원 관리" />
       {children}
-      {/* {modal} */}
     </div>
   );
 }

--- a/src/app/(public)/menus/preview/layout.tsx
+++ b/src/app/(public)/menus/preview/layout.tsx
@@ -3,14 +3,8 @@ import { Suspense, type ReactNode } from "react";
 
 type LayoutProps = {
   children: ReactNode;
-  // modal?: ReactNode;
 };
 
 export default function Layout({ children }: LayoutProps) {
-  return (
-    <>
-      <Suspense fallback={<Spinner />}>{children}</Suspense>
-      {/* {modal} */}
-    </>
-  );
+  return <Suspense fallback={<Spinner />}>{children}</Suspense>;
 }


### PR DESCRIPTION
## 🚀연관된 이슈
- #이슈 번호

## 📝작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요

- [SKEU-198] 메뉴 순서 변경 시 메뉴 추가 버튼 삭제
  - 변경 전: 메뉴 순서 변경 시 추가 카드가 그대로 보여 잘못된 플로우가 될 위험이 있음
  - 변경 후: 메뉴 추가 버튼 hidden
- [SKEU-199] 메뉴 순서 변경 되지 않음
  - 변경 전: 메뉴 드래그만 가능, 드롭 및 저장 불가
  - 변경 후: 메뉴 드롭 및 저장 추가, 저장하자마자 list에 반영되도록 invalidatequeries 적용
- [SKEU-200] 메뉴 삭제가 되지 않음
  - 변경 전: 다중 삭제 시 요청 body의 형식 오류로 삭제가 되지 않음
  - 변경 후: API 명세서를 다시 확인 후 body 형식 수정

## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

[SKEU-198]: https://everyonewaiter.atlassian.net/browse/SKEU-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SKEU-199]: https://everyonewaiter.atlassian.net/browse/SKEU-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SKEU-200]: https://everyonewaiter.atlassian.net/browse/SKEU-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ