### PR TITLE
fix: QA 매장 정보, 카테고리 순서변경 수정

### DIFF
--- a/src/app/(main)/(owner)/[id]/menu/_api/menu.api.ts
+++ b/src/app/(main)/(owner)/[id]/menu/_api/menu.api.ts
@@ -30,7 +30,11 @@ export const moveCategory = async ({
   sourceId,
   targetId,
   where,
-}: PropsWithStoreId<{ sourceId: string; targetId: string; where: string }>) => {
+}: PropsWithStoreId<{
+  sourceId: string;
+  targetId: string;
+  where: "NEXT" | "PREV";
+}>) => {
   const response = await instance.post(
     `${API_PATH.stores}/${storeId}/categories/${sourceId}/move/${targetId}`,
     {

--- a/src/app/(main)/(owner)/[id]/menu/_components/CategoryForm.tsx
+++ b/src/app/(main)/(owner)/[id]/menu/_components/CategoryForm.tsx
@@ -1,4 +1,4 @@
-import { RefObject } from "react";
+import { RefObject, useRef } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 import { SortableContext } from "@dnd-kit/sortable";
 import { DndContext } from "@dnd-kit/core";
@@ -23,6 +23,7 @@ export default function CategoryForm({
     name: "categories",
   });
   const moveMutation = categoryQueries.useMoveCategory();
+  const scrollRef = useRef<HTMLDivElement>(null);
 
   const restrictToVerticalAxis = ({ transform }: any) => ({
     ...transform,
@@ -60,7 +61,10 @@ export default function CategoryForm({
   };
 
   return (
-    <div className="scrollbar-hide overflow-y-auto md:h-[270px] lg:h-[424px]">
+    <div
+      className="scrollbar-hide overflow-y-auto md:h-[270px] lg:h-[424px]"
+      ref={scrollRef}
+    >
       {optionState === "move" ? (
         <DndContext
           modifiers={[restrictToParentElement, restrictToVerticalAxis]}
@@ -81,7 +85,13 @@ export default function CategoryForm({
             const sourceId = source?.categoryId as string;
             const targetId = target?.categoryId as string;
 
+            const prevScrollTop = scrollRef.current?.scrollTop ?? 0;
             move(from, to);
+            requestAnimationFrame(() => {
+              if (scrollRef.current) {
+                scrollRef.current.scrollTop = prevScrollTop;
+              }
+            });
 
             if (!isTempOrAdded(source) && !isTempOrAdded(target)) {
               moveMutation.mutate({ storeId, sourceId, targetId, where });

--- a/src/app/(main)/(owner)/[id]/menu/_components/CategoryForm.tsx
+++ b/src/app/(main)/(owner)/[id]/menu/_components/CategoryForm.tsx
@@ -75,20 +75,14 @@ export default function CategoryForm({
             const to = fields.findIndex((f: any) => f.categoryId === overId);
             if (from === -1 || to === -1) return;
 
-            const where = from < to ? "NEXT" : "PREVIOUS";
+            const where = from < to ? "NEXT" : "PREV";
             const source = fields[from] as any;
             const target = fields[to] as any;
             const sourceId = source?.categoryId as string;
             const targetId = target?.categoryId as string;
 
-            // 1) UI: move locally
             move(from, to);
 
-            console.log(
-              `source: ${source.name} -> target: ${target.name} ${where}`
-            );
-
-            // 2) Server: only if both persisted
             if (!isTempOrAdded(source) && !isTempOrAdded(target)) {
               moveMutation.mutate({ storeId, sourceId, targetId, where });
             }

--- a/src/app/(main)/(owner)/[id]/store/_components/FormComponent.tsx
+++ b/src/app/(main)/(owner)/[id]/store/_components/FormComponent.tsx
@@ -83,9 +83,12 @@ export default function FormComponent({ storeId }: IProps) {
                   placeholder="매장 전화번호"
                   onChange={(e) => {
                     const formatted = phoneNumberPattern(e.target.value);
-                    form.setValue("landline", formatted);
+                    form.setValue("landline", formatted, {
+                      shouldDirty: true,
+                    });
                   }}
                   disabled={!isEditing}
+                  readOnly={isSubmitted}
                   hasError={!!form.formState.errors.landline}
                 />
               </div>
@@ -98,6 +101,7 @@ export default function FormComponent({ storeId }: IProps) {
                 isEditing={isEditing}
                 fields={fields}
                 removeOrigin={removeOrigin}
+                isSubmitted={isSubmitted}
               />
             </FormProvider>
           ) : (
@@ -178,7 +182,7 @@ export default function FormComponent({ storeId }: IProps) {
                     },
                   }}
                   commonClassName="w-full"
-                  disabled={isSubmitted}
+                  disabled={isSubmitted || !form.formState.isDirty}
                 >
                   {isSubmitted ? <Spinner /> : "저장하기"}
                 </ResponsiveButton>

--- a/src/app/(main)/(owner)/[id]/store/_components/Origins.tsx
+++ b/src/app/(main)/(owner)/[id]/store/_components/Origins.tsx
@@ -23,9 +23,15 @@ interface IProps {
   isEditing: boolean;
   fields: FieldArrayWithId<TypeStoreInfo, "origins", "id">[];
   removeOrigin: UseFieldArrayRemove;
+  isSubmitted: boolean;
 }
 
-export default function Origins({ isEditing, fields, removeOrigin }: IProps) {
+export default function Origins({
+  isEditing,
+  fields,
+  removeOrigin,
+  isSubmitted,
+}: IProps) {
   const isLargeScreen = useMediaQuery({ query: "(min-width: 961px)" });
 
   const form = useFormContext<TypeStoreInfo>();
@@ -56,6 +62,7 @@ export default function Origins({ isEditing, fields, removeOrigin }: IProps) {
                 }
                 {...form.register(`origins.${idx}.item`)}
                 className="w-full text-center outline-none"
+                disabled={isSubmitted}
               />
             ) : (
               item.item
@@ -69,6 +76,7 @@ export default function Origins({ isEditing, fields, removeOrigin }: IProps) {
                 }
                 {...form.register(`origins.${idx}.origin`)}
                 className="w-full text-center outline-none"
+                disabled={isSubmitted}
               />
             ) : (
               item.origin

--- a/src/app/(main)/(owner)/[id]/store/_hooks/useStoreForm.ts
+++ b/src/app/(main)/(owner)/[id]/store/_hooks/useStoreForm.ts
@@ -35,13 +35,6 @@ export default function useStoreForm(storeId: string) {
     action: UseMutationResult<any, Error, any, unknown>,
     successHandler: () => void
   ) => {
-    if (!form.formState.isDirty) {
-      // eslint-disable-next-line
-      alert("변경사항이 없습니다.");
-      successHandler();
-      return;
-    }
-
     setIsSubmitted(true);
     const origins = form.getValues("origins");
 

--- a/src/hooks/useOptimisticReorder.ts
+++ b/src/hooks/useOptimisticReorder.ts
@@ -4,7 +4,7 @@ import { QueryClient, QueryKey, useMutation } from "@tanstack/react-query";
 interface MoveParams {
   sourceId: string;
   targetId: string;
-  where: "NEXT" | "PREVIOUS";
+  where: "NEXT" | "PREV";
   storeId: string;
 }
 


### PR DESCRIPTION
## 🚀연관된 이슈
- #이슈 번호

## 📝작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요

- [SKEU-244] 매장 전화번호 수정 시 안내문구 수정
  - 변경 전: 전화번호를 변경해도 변경 사항이 없다는 알럿 뜸
  - 변경 후: react-hook-form에서 값 변경을 감지하도록 전화번호 변경시 isDirty: true 추가
- [SKEU-184] 카테고리 순서 변경 오류
  - 변경 전: 순서 변경 시 변경 순서대로 저장되지 않는 오류 발견
  - 변경 후: 순서 변경 로직 새로 작성, form categories 값과 fields를 분리

## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

[SKEU-244]: https://everyonewaiter.atlassian.net/browse/SKEU-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SKEU-184]: https://everyonewaiter.atlassian.net/browse/SKEU-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ