### PR TITLE
fix: QA 메뉴 삭제 또는 오더 삭제 시 주문 취소서 출력

### DIFF
--- a/src/app/(device-required)/layout.tsx
+++ b/src/app/(device-required)/layout.tsx
@@ -52,7 +52,6 @@ export default function Layout({
   }, [queryClient]);
 
   useEffect(() => {
-    // /device 경로에서는 검증을 건너뛰기
     if (pathname === "/device") {
       setIsChecking(false);
       return;

--- a/src/app/(device-required)/pos/_components/SideSection/SideSection.tsx
+++ b/src/app/(device-required)/pos/_components/SideSection/SideSection.tsx
@@ -16,7 +16,6 @@ import SideHeader from "./SideHeader";
 import SideLayout from "./SideLayout";
 import SidePayment from "./SidePayment";
 import { posKeys } from "../../_queries/keys";
-import { printCancelToKitchen } from "../../_utils/print-fn/print-kitchen";
 
 const MemoAlert = dynamic(() => import("../modals/MemoAlert"), {
   ssr: false,
@@ -70,19 +69,11 @@ export default function SideSection() {
 
     await Promise.all(cancelPromises).then(() => {
       setSelectedOrder([]);
-      const now = new Date();
 
-      printCancelToKitchen({
-        cancelledMenus: selectedOrder.map((el) => el.orderMenus).flat(),
-        tableNo,
-        cancelledTime: now,
-        successHandler: () => {
-          if (data?.orders.length === 0) {
-            complete.mutate({ tableNo });
-            navigate.push("/pos/tables");
-          }
-        },
-      });
+      if (data?.orders.length === 0) {
+        complete.mutate({ tableNo });
+        navigate.push("/pos/tables");
+      }
     });
   };
 
@@ -92,12 +83,6 @@ export default function SideSection() {
       alert("수정할 메뉴를 선택해주세요.");
       return;
     }
-
-    const cancelledMenus = selectedMenu.filter((el) => {
-      const newQuantity =
-        type === "add" ? (el?.quantity ?? 0) + 1 : (el?.quantity ?? 0) - 1;
-      return newQuantity <= 0;
-    });
 
     updateOrder.mutate(
       {
@@ -124,20 +109,12 @@ export default function SideSection() {
             queryKey: posKeys.activity(data?.tableNo!),
           });
 
-          const now = new Date();
-          printCancelToKitchen({
-            cancelledMenus,
-            tableNo,
-            cancelledTime: now,
-            successHandler: () => {
-              if (!data?.orders?.length) {
-                complete.mutate(
-                  { tableNo },
-                  { onSuccess: () => navigate.push("/pos/tables") }
-                );
-              }
-            },
-          });
+          if (!data?.orders?.length) {
+            complete.mutate(
+              { tableNo },
+              { onSuccess: () => navigate.push("/pos/tables") }
+            );
+          }
         },
       }
     );

--- a/src/app/(device-required)/pos/_components/SideSection/SideSection.tsx
+++ b/src/app/(device-required)/pos/_components/SideSection/SideSection.tsx
@@ -16,6 +16,7 @@ import SideHeader from "./SideHeader";
 import SideLayout from "./SideLayout";
 import SidePayment from "./SidePayment";
 import { posKeys } from "../../_queries/keys";
+import { printCancelToKitchen } from "../../_utils/print-fn/print-kitchen";
 
 const MemoAlert = dynamic(() => import("../modals/MemoAlert"), {
   ssr: false,
@@ -69,10 +70,19 @@ export default function SideSection() {
 
     await Promise.all(cancelPromises).then(() => {
       setSelectedOrder([]);
-      if (data?.orders.length === 0) {
-        complete.mutate({ tableNo });
-        navigate.push("/pos/tables");
-      }
+      const now = new Date();
+
+      printCancelToKitchen({
+        cancelledMenus: selectedOrder.map((el) => el.orderMenus).flat(),
+        tableNo,
+        cancelledTime: now,
+        successHandler: () => {
+          if (data?.orders.length === 0) {
+            complete.mutate({ tableNo });
+            navigate.push("/pos/tables");
+          }
+        },
+      });
     });
   };
 
@@ -82,6 +92,12 @@ export default function SideSection() {
       alert("수정할 메뉴를 선택해주세요.");
       return;
     }
+
+    const cancelledMenus = selectedMenu.filter((el) => {
+      const newQuantity =
+        type === "add" ? (el?.quantity ?? 0) + 1 : (el?.quantity ?? 0) - 1;
+      return newQuantity <= 0;
+    });
 
     updateOrder.mutate(
       {
@@ -107,13 +123,21 @@ export default function SideSection() {
           queryClient.invalidateQueries({
             queryKey: posKeys.activity(data?.tableNo!),
           });
-          console.log(data?.orders);
-          if (!data?.orders?.length) {
-            complete.mutate(
-              { tableNo },
-              { onSuccess: () => navigate.push("/pos/tables") }
-            );
-          }
+
+          const now = new Date();
+          printCancelToKitchen({
+            cancelledMenus,
+            tableNo,
+            cancelledTime: now,
+            successHandler: () => {
+              if (!data?.orders?.length) {
+                complete.mutate(
+                  { tableNo },
+                  { onSuccess: () => navigate.push("/pos/tables") }
+                );
+              }
+            },
+          });
         },
       }
     );

--- a/src/app/(device-required)/pos/_utils/print-fn/print-kitchen.ts
+++ b/src/app/(device-required)/pos/_utils/print-fn/print-kitchen.ts
@@ -61,7 +61,7 @@ export const printToKitchen = ({ successHandler, close, ...props }: IProps) => {
   }
   props.receiptMenus.forEach((menu) => {
     window.printText(
-      `${formatAlignLeftRight(menu.name, `${menu.quantity}원`, 1)}\n`,
+      `${formatAlignLeftRight(menu.name, `${menu.quantity}`, 1)}\n`,
       1,
       1,
       true,
@@ -128,13 +128,12 @@ export const printCancelToKitchen = ({
   );
 
   printDivider();
-  printDivider();
 
   window.printText("취소된 품목:\n\n", 0, 0, false, false, false, 0, 0);
 
   cancelledMenus.forEach((menu) => {
     window.printText(
-      `${formatAlignLeftRight(menu.name, `-${menu.quantity}개`, 1)}\n`,
+      `${formatAlignLeftRight(menu.name, `${menu.quantity}개`, 1)}\n`,
       1,
       1,
       true,

--- a/src/app/(device-required)/pos/_utils/print-fn/print-kitchen.ts
+++ b/src/app/(device-required)/pos/_utils/print-fn/print-kitchen.ts
@@ -61,7 +61,7 @@ export const printToKitchen = ({ successHandler, close, ...props }: IProps) => {
   }
   props.receiptMenus.forEach((menu) => {
     window.printText(
-      `${(formatAlignLeftRight(menu.name, String(menu.quantity)), 1)}\n`,
+      `${formatAlignLeftRight(menu.name, `${menu.quantity}원`, 1)}\n`,
       1,
       1,
       true,
@@ -99,20 +99,27 @@ export const printToKitchen = ({ successHandler, close, ...props }: IProps) => {
 export const printCancelToKitchen = ({
   cancelledMenus,
   tableNo,
+  printNo,
   cancelledTime,
   successHandler,
 }: {
-  cancelledMenus: TableOrderMenu[];
+  cancelledMenus: {
+    name: string;
+    options: string[];
+    quantity: number;
+  }[];
   tableNo: number;
+  printNo: number;
   cancelledTime: Date;
   successHandler?: () => void;
 }) => {
   window.printText(`주문 취소서\n\n`, 1, 1, true, false, false, 0, 1);
+  window.printText(`주문번호: ${printNo}\n`, 0, 1, true, false, false, 0, 0);
   window.printText(`테이블번호: ${tableNo}\n`, 0, 1, true, false, false, 0, 0);
   window.printText(
     `취소 시간: ${formatted(cancelledTime)}\n`,
     0,
-    1,
+    0,
     true,
     false,
     false,
@@ -121,12 +128,13 @@ export const printCancelToKitchen = ({
   );
 
   printDivider();
+  printDivider();
 
   window.printText("취소된 품목:\n\n", 0, 0, false, false, false, 0, 0);
 
   cancelledMenus.forEach((menu) => {
     window.printText(
-      `${menu.name} - ${menu.quantity}개`,
+      `${formatAlignLeftRight(menu.name, `-${menu.quantity}개`, 1)}\n`,
       1,
       1,
       true,
@@ -135,12 +143,12 @@ export const printCancelToKitchen = ({
       0,
       0
     );
-    menu.orderOptionGroups.forEach((option) => {
+    menu.options.forEach((option) => {
       window.printText(`${option}`, 0, 1, true, false, false, 0, 0);
     });
   });
 
-  window.printText("\n\n", 0, 0, false, false, false, 0, 0);
+  window.printText("\n\n\n", 0, 0, false, false, false, 0, 0);
 
   window.cutPaper(1);
 

--- a/src/app/(device-required)/pos/_utils/print-fn/print-kitchen.ts
+++ b/src/app/(device-required)/pos/_utils/print-fn/print-kitchen.ts
@@ -1,5 +1,10 @@
 import { PRINTERNAME } from "@/constants/printerName";
-import { checkPrinter, formatAlignLeftRight, printDivider } from "./utils";
+import {
+  checkPrinter,
+  formatAlignLeftRight,
+  formatted,
+  printDivider,
+} from "./utils";
 
 interface IProps extends ReceiptSSE {
   successHandler?: () => void;
@@ -7,7 +12,17 @@ interface IProps extends ReceiptSSE {
 }
 
 export const printToKitchen = ({ successHandler, close, ...props }: IProps) => {
-  window.printText(`${props.printNo}\n`, 2, 2, true, false, false, 0, 1);
+  window.printText(`주문서\n\n`, 1, 1, true, false, false, 0, 1);
+  window.printText(
+    `주문번호: ${props.printNo}\n`,
+    0,
+    1,
+    true,
+    false,
+    false,
+    0,
+    1
+  );
   window.printText(
     `테이블번호: ${props.tableNo}\n`,
     0,
@@ -56,7 +71,72 @@ export const printToKitchen = ({ successHandler, close, ...props }: IProps) => {
       0
     );
     menu.options.forEach((option) => {
-      window.printText(`└ ${option}\n`, 1, 0, true, false, false, 0, 0);
+      window.printText(`${option}\n`, 1, 0, true, false, false, 0, 0);
+    });
+  });
+
+  window.printText("\n\n", 0, 0, false, false, false, 0, 0);
+
+  window.cutPaper(1);
+
+  const strSubmit = window.getPosData();
+
+  checkPrinter(PRINTERNAME.PRINTER2, (exists) => {
+    if (!exists) {
+      // eslint-disable-next-line
+      alert(
+        "주방 프린터 연결을 확인해주세요. Web Print SDK가 실행되지 않았거나 프린터가 연결되지 않았습니다."
+      );
+      return;
+    }
+
+    window.requestPrint(PRINTERNAME.PRINTER2, strSubmit, () => {
+      successHandler?.();
+    });
+  });
+};
+
+export const printCancelToKitchen = ({
+  cancelledMenus,
+  tableNo,
+  cancelledTime,
+  successHandler,
+}: {
+  cancelledMenus: TableOrderMenu[];
+  tableNo: number;
+  cancelledTime: Date;
+  successHandler?: () => void;
+}) => {
+  window.printText(`주문 취소서\n\n`, 1, 1, true, false, false, 0, 1);
+  window.printText(`테이블번호: ${tableNo}\n`, 0, 1, true, false, false, 0, 0);
+  window.printText(
+    `취소 시간: ${formatted(cancelledTime)}\n`,
+    0,
+    1,
+    true,
+    false,
+    false,
+    0,
+    0
+  );
+
+  printDivider();
+
+  window.printText("취소된 품목:\n", 0, 0, false, false, false, 0, 0);
+
+  cancelledMenus.forEach((menu) => {
+    window.printText(
+      `${formatAlignLeftRight(menu.name, String(menu.quantity))}\n`,
+      0,
+      0,
+      true,
+      false,
+      false,
+      0,
+      0
+    );
+    menu.orderOptionGroups.forEach((option) => {
+      window.printText(`${option}`, 0, 0, true, false, false, 0, 0);
     });
   });
 

--- a/src/app/(device-required)/pos/_utils/print-fn/print-kitchen.ts
+++ b/src/app/(device-required)/pos/_utils/print-fn/print-kitchen.ts
@@ -21,7 +21,7 @@ export const printToKitchen = ({ successHandler, close, ...props }: IProps) => {
     false,
     false,
     0,
-    1
+    0
   );
   window.printText(
     `테이블번호: ${props.tableNo}\n`,
@@ -71,7 +71,7 @@ export const printToKitchen = ({ successHandler, close, ...props }: IProps) => {
       0
     );
     menu.options.forEach((option) => {
-      window.printText(`${option}\n`, 1, 0, true, false, false, 0, 0);
+      window.printText(`${option}\n`, 0, 1, true, false, false, 0, 0);
     });
   });
 
@@ -122,13 +122,13 @@ export const printCancelToKitchen = ({
 
   printDivider();
 
-  window.printText("취소된 품목:\n", 0, 0, false, false, false, 0, 0);
+  window.printText("취소된 품목:\n\n", 0, 0, false, false, false, 0, 0);
 
   cancelledMenus.forEach((menu) => {
     window.printText(
-      `${formatAlignLeftRight(menu.name, String(menu.quantity))}\n`,
-      0,
-      0,
+      `${menu.name} - ${menu.quantity}개`,
+      1,
+      1,
       true,
       false,
       false,
@@ -136,7 +136,7 @@ export const printCancelToKitchen = ({
       0
     );
     menu.orderOptionGroups.forEach((option) => {
-      window.printText(`${option}`, 0, 0, true, false, false, 0, 0);
+      window.printText(`${option}`, 0, 1, true, false, false, 0, 0);
     });
   });
 

--- a/src/app/(device-required)/pos/_utils/print-fn/print-refund.ts
+++ b/src/app/(device-required)/pos/_utils/print-fn/print-refund.ts
@@ -3,6 +3,7 @@ import {
   checkPrinter,
   formatAlignLeftRight,
   formatReceiptRow,
+  formatted,
   printDivider,
 } from "./utils";
 
@@ -59,26 +60,8 @@ export const printRefund = ({
       0
     );
 
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = now.getMonth() + 1;
-    const day = now.getDate();
-    const hours = now.getHours();
-    const minutes = now.getMinutes();
-    const period = hours >= 12 ? "오후" : "오전";
-    let displayHours: number;
-    if (hours > 12) {
-      displayHours = hours - 12;
-    } else if (hours === 0) {
-      displayHours = 12;
-    } else {
-      displayHours = hours;
-    }
-
-    const formattedTime = `${displayHours}:${minutes.toString().padStart(2, "0")}`;
-
     window.printText(
-      `발행일시: ${year}. ${month}. ${day}. ${period} ${formattedTime}\n`,
+      `발행일시: ${formatted()}\n`,
       0,
       0,
       true,

--- a/src/app/(device-required)/pos/_utils/print-fn/utils.ts
+++ b/src/app/(device-required)/pos/_utils/print-fn/utils.ts
@@ -119,6 +119,28 @@ const printBaseRow = (text: string, value: string) => {
   return `${text + spacing + value}\n`;
 };
 
+const formatted = (initialDate?: Date) => {
+  const now = initialDate || new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth() + 1;
+  const day = now.getDate();
+  const hours = now.getHours();
+  const minutes = now.getMinutes();
+  const period = hours >= 12 ? "오후" : "오전";
+  let displayHours: number;
+  if (hours > 12) {
+    displayHours = hours - 12;
+  } else if (hours === 0) {
+    displayHours = 12;
+  } else {
+    displayHours = hours;
+  }
+
+  const time = `${displayHours}:${minutes.toString().padStart(2, "0")}`;
+
+  return `${year}. ${month}. ${day}. ${period} ${time}`;
+};
+
 export {
   formatAlignLeftRight,
   formatReceiptRow,
@@ -127,4 +149,5 @@ export {
   checkPrinter,
   countUnits,
   printBaseRow,
+  formatted,
 };

--- a/src/app/(public)/device/layout.tsx
+++ b/src/app/(public)/device/layout.tsx
@@ -31,7 +31,8 @@ export default function Layout({ children }: PropsWithChildren) {
     };
 
     checkDeviceInfo();
-  }, []); // navigate 의존성 제거
+    // eslint-disable-next-line
+  }, []);
 
   if (isLoading) {
     return <FirstLoading />;

--- a/src/components/guard/KitchenSSEGuard.tsx
+++ b/src/components/guard/KitchenSSEGuard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PropsWithChildren, useEffect } from "react";
+import { PropsWithChildren, useEffect, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { storeKeys } from "@/app/(main)/(owner)/[id]/store/_queries/keys";
 import { getStoreInfoDetail } from "@/app/(main)/(owner)/[id]/store/_api/stores.api";
@@ -23,6 +23,9 @@ export default function KitchenSSEGuard({
   const queryClient = getQueryClient();
   const { storeId } = useDeviceContext();
 
+  // 처리된 printNo를 추적하여 중복 방지
+  const processedPrintNos = useRef(new Set<number>());
+
   const { data: settingData } = useQuery({
     queryKey: storeKeys.detail(storeId!),
     queryFn: () => getStoreInfoDetail(storeId!),
@@ -31,6 +34,9 @@ export default function KitchenSSEGuard({
 
   useEffect(() => {
     const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
+      // 데이터 업데이트 이벤트만 처리
+      if (event.type !== "updated") return;
+
       if (
         JSON.stringify(event.query.queryKey) ===
         JSON.stringify(["kitchen-receipt-trigger"])
@@ -41,6 +47,17 @@ export default function KitchenSSEGuard({
           receiptTrigger?.printNo &&
           settingData?.setting?.printerLocation === allowedPurpose.toUpperCase()
         ) {
+          // 이미 처리된 printNo인지 확인
+          if (processedPrintNos.current.has(receiptTrigger.printNo)) {
+            console.log(
+              `PrintNo ${receiptTrigger.printNo} already processed, skipping`
+            );
+            return;
+          }
+
+          // 처리된 printNo 추가
+          processedPrintNos.current.add(receiptTrigger.printNo);
+
           const hasCancelledMenus = receiptTrigger.receiptMenus.some(
             (menu) => menu.quantity === -1
           );
@@ -55,20 +72,42 @@ export default function KitchenSSEGuard({
               tableNo: receiptTrigger.tableNo,
               printNo: receiptTrigger.printNo,
               cancelledTime: new Date(),
+              successHandler: () => {
+                // 성공 후 쿼리 정리
+                queryClient.setQueryData(
+                  ["kitchen-receipt-trigger"],
+                  undefined
+                );
+                queryClient.removeQueries({
+                  queryKey: ["kitchen-receipt-trigger"],
+                });
+              },
             });
           } else {
-            printToKitchen(receiptTrigger);
+            printToKitchen({
+              ...receiptTrigger,
+              successHandler: () => {
+                // 성공 후 쿼리 정리
+                queryClient.setQueryData(
+                  ["kitchen-receipt-trigger"],
+                  undefined
+                );
+                queryClient.removeQueries({
+                  queryKey: ["kitchen-receipt-trigger"],
+                });
+              },
+            });
           }
 
-          queryClient.setQueryData(["kitchen-receipt-trigger"], undefined);
-          queryClient.removeQueries({ queryKey: ["kitchen-receipt-trigger"] });
+          setTimeout(() => {
+            processedPrintNos.current.delete(receiptTrigger.printNo);
+          }, 5000);
         }
       }
     });
 
     return () => unsubscribe();
-    // eslint-disable-next-line
-  }, [queryClient, settingData]);
+  }, [queryClient, settingData, allowedPurpose]);
 
   return children;
 }

--- a/src/components/guard/KitchenSSEGuard.tsx
+++ b/src/components/guard/KitchenSSEGuard.tsx
@@ -6,7 +6,10 @@ import { storeKeys } from "@/app/(main)/(owner)/[id]/store/_queries/keys";
 import { getStoreInfoDetail } from "@/app/(main)/(owner)/[id]/store/_api/stores.api";
 import { isNumber } from "@/utils/validate";
 import getQueryClient from "@/app/get-query-client";
-import { printToKitchen } from "@/app/(device-required)/pos/_utils/print-fn/print-kitchen";
+import {
+  printToKitchen,
+  printCancelToKitchen,
+} from "@/app/(device-required)/pos/_utils/print-fn/print-kitchen";
 import { useDeviceContext } from "@/providers/deviceStoreProvider";
 
 interface IProps {
@@ -29,9 +32,8 @@ export default function KitchenSSEGuard({
   useEffect(() => {
     const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
       if (
-        event.type === "updated" &&
         JSON.stringify(event.query.queryKey) ===
-          JSON.stringify(["kitchen-receipt-trigger"])
+        JSON.stringify(["kitchen-receipt-trigger"])
       ) {
         const receiptTrigger = event.query.state.data as ReceiptSSE;
 
@@ -39,7 +41,25 @@ export default function KitchenSSEGuard({
           receiptTrigger?.printNo &&
           settingData?.setting?.printerLocation === allowedPurpose.toUpperCase()
         ) {
-          printToKitchen(receiptTrigger);
+          const hasCancelledMenus = receiptTrigger.receiptMenus.some(
+            (menu) => menu.quantity === -1
+          );
+
+          if (hasCancelledMenus) {
+            const cancelledMenus = receiptTrigger.receiptMenus.filter(
+              (menu) => menu.quantity === -1
+            );
+
+            printCancelToKitchen({
+              cancelledMenus,
+              tableNo: receiptTrigger.tableNo,
+              printNo: receiptTrigger.printNo,
+              cancelledTime: new Date(),
+            });
+          } else {
+            printToKitchen(receiptTrigger);
+          }
+
           queryClient.removeQueries({ queryKey: ["kitchen-receipt-trigger"] });
         }
       }

--- a/src/components/guard/KitchenSSEGuard.tsx
+++ b/src/components/guard/KitchenSSEGuard.tsx
@@ -60,6 +60,7 @@ export default function KitchenSSEGuard({
             printToKitchen(receiptTrigger);
           }
 
+          queryClient.setQueryData(["kitchen-receipt-trigger"], undefined);
           queryClient.removeQueries({ queryKey: ["kitchen-receipt-trigger"] });
         }
       }

--- a/src/utils/sse.ts
+++ b/src/utils/sse.ts
@@ -161,9 +161,6 @@ export class SseService {
               ["kitchen-receipt-trigger"],
               sseEvent.data
             );
-            queryClient.invalidateQueries({
-              queryKey: ["kitchen-receipt-trigger"],
-            });
           }
           break;
         case "POS":

--- a/src/utils/sse.ts
+++ b/src/utils/sse.ts
@@ -124,7 +124,6 @@ export class SseService {
       switch (sseEvent.category) {
         case "DEVICE":
           if (sseEvent.hasData) {
-            console.log(sseEvent.hasData);
             if (sseEvent?.action === "UPDATE") {
               queryClient.setQueryData(["update-device"], sseEvent.data);
             }

--- a/src/utils/sse.ts
+++ b/src/utils/sse.ts
@@ -157,10 +157,20 @@ export class SseService {
           break;
         case "RECEIPT":
           if (sseEvent.hasData) {
-            queryClient.setQueryData(
-              ["kitchen-receipt-trigger"],
-              sseEvent.data
-            );
+            // queryClient.setQueryData(
+            //   ["kitchen-receipt-trigger"],
+            //   sseEvent.data
+            // );
+            const existingData = queryClient.getQueryData([
+              "kitchen-receipt-trigger",
+            ]);
+            const newData = JSON.parse(sseEvent.data);
+            if (
+              !existingData ||
+              (existingData as any)?.printNo !== newData.printNo
+            ) {
+              queryClient.setQueryData(["kitchen-receipt-trigger"], newData);
+            }
           }
           break;
         case "POS":

--- a/src/utils/sse.ts
+++ b/src/utils/sse.ts
@@ -157,20 +157,10 @@ export class SseService {
           break;
         case "RECEIPT":
           if (sseEvent.hasData) {
-            // queryClient.setQueryData(
-            //   ["kitchen-receipt-trigger"],
-            //   sseEvent.data
-            // );
-            const existingData = queryClient.getQueryData([
-              "kitchen-receipt-trigger",
-            ]);
-            const newData = JSON.parse(sseEvent.data);
-            if (
-              !existingData ||
-              (existingData as any)?.printNo !== newData.printNo
-            ) {
-              queryClient.setQueryData(["kitchen-receipt-trigger"], newData);
-            }
+            queryClient.setQueryData(
+              ["kitchen-receipt-trigger"],
+              sseEvent.data
+            );
           }
           break;
         case "POS":


### PR DESCRIPTION
## 🚀연관된 이슈
- #이슈 번호

## 📝작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요

- [SKEU-326]
  - 주문 취소에 대한 증명 자료 (=빌지) 필요해서 주문 취소서 생성
  - 포함된 정보: 주문 번호, 테이블 번호, 취소 시간, 취소된 품목, 품목명, 삭제되는 값, 옵션 등
  - 처음에 두개씩 출력되는 에러가 있었으나, setQueryData와 invalidateQueries를 중복 사용했기 떄문인 것 같음
  - **추후 주문 변경서를 만들어야할지 고민입니다.**

## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- **내일 태스트**: 테이블 주문 서비스 사용 테스트, 현금 영수증 구현 수정, 결제/주문 완료 시 페이지 이동 

[SKEU-326]: https://everyonewaiter.atlassian.net/browse/SKEU-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ