### PR TITLE
fix: 카드 결제 취소 에러 수정 및 영수증 모달 선택 변경

### DIFF
--- a/src/app/(device-required)/pos/_components/modals/CancelAlert.tsx
+++ b/src/app/(device-required)/pos/_components/modals/CancelAlert.tsx
@@ -79,7 +79,6 @@ export default function CancelAlert({
       if (orderPayment.method === "CARD") {
         cancelCard({
           orderPayment,
-          totalPaymentPrice: activity.totalPaymentPrice!,
           terminalId: stores?.setting?.ksnetDeviceNo!,
           successHandler: () => {
             close();

--- a/src/app/(device-required)/pos/_components/modals/CancelAlert.tsx
+++ b/src/app/(device-required)/pos/_components/modals/CancelAlert.tsx
@@ -78,7 +78,7 @@ export default function CancelAlert({
       if (!activity.totalPaymentPrice || !orderPayment) return;
       if (orderPayment.method === "CARD") {
         cancelCard({
-          orderPaymentId: orderPayment.orderPaymentId,
+          orderPayment,
           totalPaymentPrice: activity.totalPaymentPrice!,
           terminalId: stores?.setting?.ksnetDeviceNo!,
           successHandler: () => {

--- a/src/app/(device-required)/pos/_hooks/useHandlerPay.tsx
+++ b/src/app/(device-required)/pos/_hooks/useHandlerPay.tsx
@@ -12,7 +12,6 @@ import ReceiptModal from "../_components/modals/ReceiptModal";
 import { posKeys } from "../_queries/keys";
 import { posQueries } from "../_queries/usePos";
 import { paySchema, TypePayForm } from "../_schema/pos.schema";
-import ReceiptOrderDetailModal from "../_components/modals/ReceiptOrderDetailModal";
 
 interface IProps extends PosTableActivity {
   initialPayValue: number;
@@ -50,24 +49,18 @@ export default function useHandlerPay({
   const { data: stores } = posQueries.useStoreInfo(props.storeId!);
 
   const receiptOverlay = useOverlay();
-  const includeOrderOrNotOverlay = useOverlay();
-
-  const handleNavigate = () => {
-    if (payValue === activityData?.remainingPaymentPrice) {
-      navigate.push("/pos/tables");
-      queryClient.invalidateQueries({ queryKey: posKeys.tables });
-    } else {
-      close();
-    }
-  };
 
   const handleSuccess = () => {
     if (activityData?.remainingPaymentPrice! > 0) {
       queryClient.invalidateQueries({
         queryKey: posKeys.activity(activityData?.tableNo!),
       });
+      close();
+    } else if (payValue === activityData?.remainingPaymentPrice) {
+      navigate.push("/pos/tables");
+      queryClient.invalidateQueries({ queryKey: posKeys.tables });
     } else {
-      handleNavigate();
+      close();
     }
   };
 
@@ -127,30 +120,13 @@ export default function useHandlerPay({
           }
           handleSuccess();
         }}
-        onCancel={handleNavigate}
-      />
-    ));
-  };
-
-  const handleIncludeOrderOrNotModal = (res?: PaymentResponse) => {
-    includeOrderOrNotOverlay.open(() => (
-      <ReceiptOrderDetailModal
-        close={includeOrderOrNotOverlay.close}
-        onConfirm={() => {
-          if (type === "credit-card") {
-            handlePrintCard(res, true);
-          } else {
-            handlePrintCash(res, true);
-          }
-          handleSuccess();
-        }}
         onCancel={() => {
-          if (type === "credit-card") {
-            handlePrintCard(res, false);
+          if (payValue === activityData?.remainingPaymentPrice) {
+            navigate.push("/pos/tables");
+            queryClient.invalidateQueries({ queryKey: posKeys.tables });
           } else {
-            handlePrintCash(res, false);
+            close();
           }
-          handleSuccess();
         }}
       />
     ));
@@ -167,11 +143,7 @@ export default function useHandlerPay({
         terminalId: storesDetail?.setting?.ksnetDeviceNo!,
         successHandler: (res) => {
           close();
-          if (activityData?.remainingPaymentPrice !== payValue) {
-            handleIncludeOrderOrNotModal(res);
-          } else {
-            handleModal(res);
-          }
+          handleModal(res);
         },
       });
     } else {
@@ -186,11 +158,7 @@ export default function useHandlerPay({
         terminalId: storesDetail?.setting?.ksnetDeviceNo!,
         successHandler: (res) => {
           close();
-          if (activityData?.remainingPaymentPrice !== payValue) {
-            handleIncludeOrderOrNotModal(res);
-          } else {
-            handleModal(res);
-          }
+          handleModal(res);
         },
       });
     }

--- a/src/app/(device-required)/pos/_queries/usePayment.ts
+++ b/src/app/(device-required)/pos/_queries/usePayment.ts
@@ -188,23 +188,51 @@ export default function usePayment() {
         REQ: req,
       },
       success: (res: PaymentResponse) => {
-        handlePayWithCard({
-          tableNo,
-          body: {
-            amount,
-            vat: amount - nonTax,
-            supplyAmount: nonTax,
-            approvalNo: res.APPROVALNO,
-            installment,
-            cardNo: res.FILLER,
-            purchaseName: res.PURCHASENAME,
-            merchantNo: res.MERCHANTNUMBER,
-            tradeTime: res.TRADETIME,
-            tradeUniqueNo: res.TRADEUNIQUENO,
-            issuerName: res.CARDNAME,
-          },
-          successHandler: () => successHandler(res),
-        });
+        switch (res.RESPCODE) {
+          case "0000":
+            handlePayWithCard({
+              tableNo,
+              body: {
+                amount,
+                vat: amount - nonTax,
+                supplyAmount: nonTax,
+                approvalNo: res.APPROVALNO,
+                installment,
+                cardNo: res.FILLER,
+                purchaseName: res.PURCHASENAME,
+                merchantNo: res.MERCHANTNUMBER,
+                tradeTime: res.TRADETIME,
+                tradeUniqueNo: res.TRADEUNIQUENO,
+                issuerName: res.CARDNAME,
+              },
+              successHandler: () => successHandler(res),
+            });
+            break;
+          case "6003":
+          case "6005":
+            alert("유효하지 않은 카드입니다.");
+            return;
+          case "8314":
+            alert("카드 승인 실패: 카드 유효기간이 경과되었습니다.");
+            return;
+          case "8325":
+          case "8326":
+          case "8327":
+          case "8328":
+          case "8329":
+          case "8330":
+          case "8331":
+          case "8332":
+            alert(
+              "카드 한도가 초과되었습니다. 다른 결제 방법을 이용해 주세요."
+            );
+            break;
+          default:
+            alert("카드 승인 실패: 카드 승인 실패");
+        }
+      },
+      onError: (error: any) => {
+        alert(error.message);
       },
     });
   };
@@ -242,10 +270,30 @@ export default function usePayment() {
           },
           {
             onSuccess: () => {
-              successHandler?.(res);
+              if (res.RESPCODE === "0000") {
+                successHandler?.(res);
+                return;
+              }
+
+              if (res.RESPCODE === "8009") {
+                alert("원거래를 찾을 수 없습니다.");
+                return;
+              }
+
+              if (res.RESPCODE === "8032") {
+                alert("이미 취소된 거래입니다.");
+                return;
+              }
+
+              if (orderPayment?.cardNo !== res.FILLER) {
+                alert("카드 취소 실패: 카드 번호가 일치하지 않습니다.");
+              }
             },
           }
         );
+      },
+      error: (error: any) => {
+        alert(error.message);
       },
     });
   };

--- a/src/app/(device-required)/pos/_queries/usePayment.ts
+++ b/src/app/(device-required)/pos/_queries/usePayment.ts
@@ -2,7 +2,8 @@ import { useMutation } from "@tanstack/react-query";
 import { UseFormReturn } from "react-hook-form";
 import { approvePayment, cancelPayment } from "../_api/payment.api";
 import { PropsWithTableNo } from "../_api/pos.api";
-import makeKSCATApprovalREQ, {
+import {
+  cancelCardRequest,
   createCashReceiptApproval,
   createCreditCardApproval,
 } from "../_utils/make-approval-req";
@@ -209,25 +210,23 @@ export default function usePayment() {
   };
 
   const handleCancelCard = async ({
+    orderPayment,
     totalPaymentPrice,
-    orderPaymentId,
     successHandler,
     terminalId,
   }: {
     totalPaymentPrice: number;
-    orderPaymentId: string;
     successHandler?: (res: PaymentResponse) => void;
     terminalId: string;
+    orderPayment?: OrderPaymentsList;
   }) => {
     const nonTax = Math.floor(totalPaymentPrice / 1.1);
 
-    const req = makeKSCATApprovalREQ({
+    const req = cancelCardRequest({
       amount: totalPaymentPrice,
       tax: totalPaymentPrice - nonTax,
-      nonTax,
-      installment: "00",
-      type: "0",
       terminalId,
+      orderPayment,
     });
     await window.$.ajax({
       url: "http://127.0.0.1:27098/",
@@ -238,15 +237,21 @@ export default function usePayment() {
         REQ: req,
       },
       success: (res: PaymentResponse) => {
-        cancelPay.mutate({
-          orderPaymentId,
-          body: {
-            approvalNo: res.APPROVALNO,
-            tradeTime: res.TRADETIME,
-            tradeUniqueNo: res.TRADEUNIQUENO,
+        cancelPay.mutate(
+          {
+            orderPaymentId: orderPayment?.orderPaymentId!,
+            body: {
+              approvalNo: res.APPROVALNO,
+              tradeTime: res.TRADETIME,
+              tradeUniqueNo: res.TRADEUNIQUENO,
+            },
           },
-        });
-        successHandler?.(res);
+          {
+            onSuccess: () => {
+              successHandler?.(res);
+            },
+          }
+        );
       },
     });
   };

--- a/src/app/(device-required)/pos/_queries/usePayment.ts
+++ b/src/app/(device-required)/pos/_queries/usePayment.ts
@@ -211,20 +211,14 @@ export default function usePayment() {
 
   const handleCancelCard = async ({
     orderPayment,
-    totalPaymentPrice,
     successHandler,
     terminalId,
   }: {
-    totalPaymentPrice: number;
     successHandler?: (res: PaymentResponse) => void;
     terminalId: string;
     orderPayment?: OrderPaymentsList;
   }) => {
-    const nonTax = Math.floor(totalPaymentPrice / 1.1);
-
     const req = cancelCardRequest({
-      amount: totalPaymentPrice,
-      tax: totalPaymentPrice - nonTax,
       terminalId,
       orderPayment,
     });

--- a/src/app/(device-required)/pos/_utils/make-approval-req.ts
+++ b/src/app/(device-required)/pos/_utils/make-approval-req.ts
@@ -26,8 +26,7 @@ export default function makeKSCATApprovalREQ({
     businessType: "01",
     messageType: type === "1" ? "0200" : "0420",
     transactionForm: "N",
-    terminalId:
-      process.env.NODE_ENV === "production" ? terminalId : "DPT0TEST03",
+    terminalId,
     companyInfo: "    ",
     seqNo: "000000000000",
     posEntryMode: " ",

--- a/src/app/(device-required)/pos/_utils/make-approval-req.ts
+++ b/src/app/(device-required)/pos/_utils/make-approval-req.ts
@@ -16,6 +16,9 @@ export default function makeKSCATApprovalREQ({
   transactionType?: "IC" | "HK";
   phoneNumber?: string;
   terminalId: string;
+  originalApprovalNo?: string;
+  originalApprovalDate?: string;
+  originalTradeUniqueNo?: string;
 }) {
   const data = {
     stx: String.fromCharCode(2),
@@ -93,4 +96,58 @@ export function createCashReceiptApproval(params: {
     phoneNumber: params.phoneNumber,
     terminalId: params.terminalId,
   });
+}
+
+export function cancelCardRequest({
+  amount,
+  tax,
+  terminalId,
+  orderPayment,
+}: {
+  amount: number;
+  tax: number;
+  terminalId: string;
+  orderPayment?: OrderPaymentsList;
+}) {
+  const data = {
+    stx: String.fromCharCode(2),
+    transactionType: "IC",
+    businessType: "01",
+    messageType: "0420",
+    transactionForm: "N",
+    terminalId:
+      process.env.NODE_ENV === "production" ? terminalId : "DPT0TEST03",
+    companyInfo: "    ",
+    seqNo: "000000000000",
+    posEntryMode: " ",
+    uniqueNo: "                    ",
+    unencryptedCardNo: "                    ",
+    encryptionYn: " ",
+    swModelNo: "                ",
+    catModelNo: "                ",
+    encryptionInfo: "                                        ",
+    trackii: "                                     ",
+    fs: String.fromCharCode(28),
+    installment: orderPayment?.installment,
+    totalAmount: String(amount).padStart(12, "0"),
+    serviceCharge: "000000000000",
+    tax: String(tax).padStart(12, "0"),
+    supplyAmount: String(orderPayment?.vat).padStart(12, "0"),
+    taxFreeAmount: "000000000000",
+    workingKeyIndex: "  ",
+    password: "                ",
+    originalApprovalNo: orderPayment?.approvalNo
+      ? orderPayment?.approvalNo?.padStart(12, " ")
+      : "            ",
+    originalApprovalDate: "      ",
+    userInfo: " ".repeat(163),
+    signYn: "X",
+    etx: String.fromCharCode(3),
+    cr: String.fromCharCode(13),
+  };
+
+  const body = Object.values(data).join("");
+  const header = `AP${body.length.toString().padStart(4, "0")}`;
+
+  return `${header}${body}`;
 }

--- a/src/app/(device-required)/pos/_utils/make-approval-req.ts
+++ b/src/app/(device-required)/pos/_utils/make-approval-req.ts
@@ -98,13 +98,9 @@ export function createCashReceiptApproval(params: {
 }
 
 export function cancelCardRequest({
-  amount,
-  tax,
   terminalId,
   orderPayment,
 }: {
-  amount: number;
-  tax: number;
   terminalId: string;
   orderPayment?: OrderPaymentsList;
 }) {
@@ -114,8 +110,7 @@ export function cancelCardRequest({
     businessType: "01",
     messageType: "0420",
     transactionForm: "N",
-    terminalId:
-      process.env.NODE_ENV === "production" ? terminalId : "DPT0TEST03",
+    terminalId,
     companyInfo: "    ",
     seqNo: "000000000000",
     posEntryMode: " ",
@@ -128,17 +123,19 @@ export function cancelCardRequest({
     trackii: "                                     ",
     fs: String.fromCharCode(28),
     installment: orderPayment?.installment,
-    totalAmount: String(amount).padStart(12, "0"),
+    totalAmount: String(orderPayment?.amount).padStart(12, "0"),
     serviceCharge: "000000000000",
-    tax: String(tax).padStart(12, "0"),
-    supplyAmount: String(orderPayment?.vat).padStart(12, "0"),
+    tax: String(orderPayment?.vat).padStart(12, "0"),
+    supplyAmount: String(orderPayment?.supplyAmount).padStart(12, "0"),
     taxFreeAmount: "000000000000",
     workingKeyIndex: "  ",
     password: "                ",
     originalApprovalNo: orderPayment?.approvalNo
       ? orderPayment?.approvalNo?.padStart(12, " ")
       : "            ",
-    originalApprovalDate: "      ",
+    originalApprovalDate: orderPayment?.tradeTime
+      ? orderPayment?.tradeTime?.substring(0, 6)
+      : "      ",
     userInfo: " ".repeat(163),
     signYn: "X",
     etx: String.fromCharCode(3),


### PR DESCRIPTION
## 🚀연관된 이슈
- #이슈 번호

## 📝작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요

- 카드 결제 취소 시 알럿이 뜨지 않아 승인된 상태로 여겨질 수 있음
  - RESPCODE (response code) 기반으로 카드 번호가 일치하지 않다면 alert 표시
  - 카드 결제 시에도 표시 (한도 초과, 유효 기간 경과 등)
- 영수증 모달 수정
  - 결제 내역에서 영수증 출력, 취소 영수증 출력인 경우 주문 내역 포함 여부를 물어보는 모달 선택
  - 결제 취소인 경우에는 전체 주문 내역 리스트업

## 📷스크린샷 (선택)
<img src="파일주소" width="50%" height="50%"/>

## 💬리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요